### PR TITLE
Next released build

### DIFF
--- a/Test Flight Release Notes.txt
+++ b/Test Flight Release Notes.txt
@@ -60,3 +60,5 @@ This build introduces several changes:
 3. The whisperer can edit all their past text, and can copy and paste it.
 4. Listeners cannot edit or copy past text (just like a conversation).
 5. Listeners can choose whether they want live text on the top (as it has been) or on the bottom (the way the whisperer sees it).
+
+NOTE: If you get a message when internet whispering about not being able to authenticate, try quitting and restarting the app.  If that doesn't work, delete and then reinstall the app.

--- a/Test Flight Release Notes.txt
+++ b/Test Flight Release Notes.txt
@@ -51,3 +51,12 @@ This is a cosmetic improvement and bug fix release:
 2. The buttons accomodate larger-size text on iPhones for us old folks.
 3. I'm collecting a bit more diagnostic data to help track down bugs.  This data is never associated with user's identities in any way.
 4. Internet listening will more reliably show the name of the whisperer.
+
+BUILDS 32 (internal) & 33 (external):
+This build introduces several changes:
+
+1. Listeners don't stop when they disconnect from a whisperer.  Instead they try to reconnect.  So connections are much more stable.
+2. When a listener connects to a whisperer, they don't get any of the whisperer's past text, just the current live text (if any).
+3. The whisperer can edit all their past text, and can copy and paste it.
+4. Listeners cannot edit or copy past text (just like a conversation).
+5. Listeners can choose whether they want live text on the top (as it has been) or on the bottom (the way the whisperer sees it).

--- a/whisper.xcodeproj/project.pbxproj
+++ b/whisper.xcodeproj/project.pbxproj
@@ -725,7 +725,7 @@
 				CODE_SIGN_ENTITLEMENTS = whisper/whisper.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 30;
+				CURRENT_PROJECT_VERSION = 32;
 				DEVELOPMENT_ASSET_PATHS = "\"whisper/Preview Content\"";
 				DEVELOPMENT_TEAM = 9BJ65G9LZ5;
 				ENABLE_PREVIEWS = YES;
@@ -766,7 +766,7 @@
 				CODE_SIGN_ENTITLEMENTS = whisper/whisper.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 30;
+				CURRENT_PROJECT_VERSION = 32;
 				DEVELOPMENT_ASSET_PATHS = "\"whisper/Preview Content\"";
 				DEVELOPMENT_TEAM = 9BJ65G9LZ5;
 				ENABLE_PREVIEWS = YES;

--- a/whisper/Info.plist
+++ b/whisper/Info.plist
@@ -14,6 +14,7 @@
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>bluetooth-central</string>
+		<string>bluetooth-peripheral</string>
 		<string>remote-notification</string>
 	</array>
 	<key>UILaunchScreen</key>

--- a/whisper/Models/PreferenceData.swift
+++ b/whisper/Models/PreferenceData.swift
@@ -33,6 +33,9 @@ struct PreferenceData {
             return id
         }
     }()
+    static func listenerMatchesWhisperer() -> Bool {
+        return defaults.bool(forKey: "listener_matches_whisperer_preference")
+    }
     // Secrets rotate.  The client generates its first secret, and always
     // sets that as both the current and prior secret.  After that, every
     // time the server sends a new secret, the current secret rotates to

--- a/whisper/Models/PreferenceData.swift
+++ b/whisper/Models/PreferenceData.swift
@@ -42,7 +42,7 @@ struct PreferenceData {
     // and it rotates the secret when that happens.  We sign auth requests
     // with the current secret, but the server allows use of the prior
     // secret as a one-time fallback when we've gone out of sync.
-    static func lastClientSecret() -> String? {
+    static func lastClientSecret() -> String {
         if let prior = defaults.string(forKey: "whisper_last_client_secret") {
             return prior
         } else {
@@ -96,20 +96,6 @@ struct PreferenceData {
     static func alertSound() -> String {
         return defaults.string(forKey: "alert_sound_preference") ?? "bike-horn"
     }
-    static func paidReceiptId() -> String? {
-        #if DEBUG
-        return defaults.string(forKey: "paid_receipt_id") ?? "debug_build_is_paid"
-        #else
-        return defaults.string(forKey: "paid_receipt_id") ?? "testing_build_is_paid"
-        #endif
-    }
-    static func updatePaidReceiptId(receiptId: String?) {
-        if let receiptId = receiptId {
-            defaults.setValue(receiptId, forKey: "paid_receipt_id")
-        } else {
-            defaults.removeObject(forKey: "paid_receipt_id")
-        }
-    }
     static var lastSubscriberUrl: String? {
         get {
             defaults.string(forKey: "last_subscriber_url")
@@ -120,6 +106,30 @@ struct PreferenceData {
             } else {
                 defaults.removeObject(forKey: "last_subscriber_url")
             }
+        }
+    }
+    static var droppedErrorCount: Int {
+        get {
+            defaults.integer(forKey: "dropped_error_count")
+        }
+        set(newVal) {
+            defaults.setValue(newVal, forKey: "dropped_error_count")
+        }
+    }
+    static var tcpErrorCount: Int {
+        get {
+            defaults.integer(forKey: "tcp_error_count")
+        }
+        set(newVal) {
+            defaults.setValue(newVal, forKey: "tcp_error_count")
+        }
+    }
+    static var authenticationErrorCount: Int {
+        get {
+            defaults.integer(forKey: "authentication_error_count")
+        }
+        set(newVal) {
+            defaults.setValue(newVal, forKey: "authentication_error_count")
         }
     }
 }

--- a/whisper/Models/Transports/Bluetooth/BluetoothListenTransport.swift
+++ b/whisper/Models/Transports/Bluetooth/BluetoothListenTransport.swift
@@ -37,6 +37,8 @@ final class BluetoothListenTransport: SubscribeTransport {
     }
     
     func goToForeground() {
+        // resume discovery
+        startDiscovery()
     }
     
     func send(remote: Remote, chunks: [TextProtocol.ProtocolChunk]) {
@@ -352,6 +354,10 @@ final class BluetoothListenTransport: SubscribeTransport {
     
     //MARK: internal methods
     private func startDiscovery() {
+        guard publisher == nil else {
+            // we don't discover if we have a publisher
+            return
+        }
         logger.log("Start scanning for whisperers")
         factory.scan(forServices: [BluetoothData.whisperServiceUuid], allow_repeats: true)
         startAdvertising()

--- a/whisper/Models/Transports/Bluetooth/BluetoothListenTransport.swift
+++ b/whisper/Models/Transports/Bluetooth/BluetoothListenTransport.swift
@@ -34,10 +34,12 @@ final class BluetoothListenTransport: SubscribeTransport {
     func goToBackground() {
         // can't do discovery in background
         stopDiscovery()
+        isInBackground = true
     }
     
     func goToForeground() {
-        // resume discovery
+        isInBackground = false
+        // resume discovery if necessary
         startDiscovery()
     }
     
@@ -156,10 +158,14 @@ final class BluetoothListenTransport: SubscribeTransport {
             logger.info("Completed drop of remote \(remote.id) with name \(remote.name)")
         } else if peripheral == publisher?.peripheral {
             logger.log("Publisher \(self.publisher!.id) has stopped publishing")
-            drop(remote: publisher!)
-        } else if let remote = remotes[peripheral] {
+            remotes.removeValue(forKey: peripheral)
+            dropRemoteSubject.send(publisher!)
+            publisher = nil
+            // lost our whisperer, look again
+            startDiscovery()
+        } else if let remote = remotes.removeValue(forKey: peripheral) {
             logger.log("Remote \(remote.id) has stopped publishing")
-            drop(remote: remote)
+            dropRemoteSubject.send(remote)
         } else {
             logger.error("Ignoring disconnect from unknown peripheral: \(peripheral)")
         }
@@ -319,6 +325,7 @@ final class BluetoothListenTransport: SubscribeTransport {
     private var remotes: [CBPeripheral: Whisperer] = [:]
     private var publisher: Remote?
     private var cancellables: Set<AnyCancellable> = []
+    private var isInBackground = false
     private var scanRefreshCount = 0
     private var disconnectsInProgress: [CBPeripheral: Remote] = [:]
     
@@ -354,6 +361,10 @@ final class BluetoothListenTransport: SubscribeTransport {
     
     //MARK: internal methods
     private func startDiscovery() {
+        guard !isInBackground else {
+            // can't do discovery in the background
+            return
+        }
         guard publisher == nil else {
             // we don't discover if we have a publisher
             return

--- a/whisper/Models/Transports/Bluetooth/BluetoothWhisperTransport.swift
+++ b/whisper/Models/Transports/Bluetooth/BluetoothWhisperTransport.swift
@@ -36,7 +36,7 @@ final class BluetoothWhisperTransport: PublishTransport {
             return
         }
         isInBackground = true
-        stopAdvertising()
+        stopDiscovery()
     }
     
     func goToForeground() {
@@ -44,6 +44,7 @@ final class BluetoothWhisperTransport: PublishTransport {
             return
         }
         isInBackground = false
+        startDiscovery()
     }
     
     func send(remote: Remote, chunks: [TextProtocol.ProtocolChunk]) {

--- a/whisper/Models/Transports/Combo/ComboFactory.swift
+++ b/whisper/Models/Transports/Combo/ComboFactory.swift
@@ -15,33 +15,15 @@ final class ComboFactory: TransportFactory {
     var statusSubject: CurrentValueSubject<TransportStatus, Never> = .init(.on)
     
     var publisherUrl: TransportUrl {
-        if PreferenceData.paidReceiptId() != nil {
-            return TcpFactory.shared.publisherUrl
-        } else {
-            return BluetoothFactory.shared.publisherUrl
-        }
+        return TcpFactory.shared.publisherUrl
     }
     
     func publisher(_ publisherUrl: TransportUrl) -> Publisher {
-        if PreferenceData.paidReceiptId() != nil {
-            return Publisher(publisherUrl)
-        } else {
-            if let url = publisherUrl {
-                logger.warning("Combo factory ignoring publisher URL in unpaid mode: \(url)")
-            }
-            return Publisher(nil)
-        }
+        return Publisher(publisherUrl)
     }
     
     func subscriber(_ publisherUrl: TransportUrl) -> Subscriber {
-        if PreferenceData.paidReceiptId() != nil {
-            return Subscriber(publisherUrl)
-        } else {
-            if let url = publisherUrl {
-                logger.warning("Combo factory ignoring subscriber URL in unpaid mode: \(url)")
-            }
-            return Subscriber(nil)
-        }
+        return Subscriber(publisherUrl)
     }
     
     //MARK: private types and properties and initialization

--- a/whisper/Models/Transports/Tcp/TcpListenTransport.swift
+++ b/whisper/Models/Transports/Tcp/TcpListenTransport.swift
@@ -18,26 +18,8 @@ final class TcpListenTransport: SubscribeTransport {
     func start(failureCallback: @escaping (String) -> Void) {
         logger.log("Starting TCP candidate transport")
         self.failureCallback = failureCallback
-        self.authenticator = TcpAuthenticator(mode: .listen, publisherId: publisherId, callback: failureCallback)
-        self.client = self.authenticator.getClient()
-        self.client.connection.on(.connected) { _ in
-            logger.log("TCP listen transport realtime client has connected")
-        }
-        self.client.connection.on(.disconnected) { _ in
-            logger.log("TCP listen transport realtime client has disconnected")
-        }
-        whisperChannel = client.channels.get(channelName)
-        whisperChannel?.on(.attached) { stateChange in
-            logger.log("TCP listen transport realtime client has attached the whisper channel")
-        }
-        whisperChannel?.on(.detached) { stateChange in
-            logger.log("TCP listen transport realtime client has detached the whisper channel")
-        }
-        whisperChannel?.attach()
-        whisperChannel?.subscribe(clientId, callback: receiveMessage)
-        whisperChannel?.subscribe("all", callback: receiveMessage)
-        whisperChannel?.presence.subscribe(receivePresence)
-        whisperChannel?.presence.enter(PreferenceData.userName())
+        self.authenticator = TcpAuthenticator(mode: .listen, publisherId: publisherId, callback: receiveAuthError)
+        openChannel()
     }
     
     func stop() {
@@ -68,7 +50,7 @@ final class TcpListenTransport: SubscribeTransport {
         }
         // we only ever have one candidate and that's the whisperer.
         // Dropping the whisperer is a mistake.
-        failureCallback?("User requested to disconnect")
+        failureCallback?("Whisperer requested a disconnect")
     }
     
     func subscribe(remote: Remote) {
@@ -107,10 +89,45 @@ final class TcpListenTransport: SubscribeTransport {
     }
     
     //MARK: Internal methods
-    func receiveErrorInfo(_ error: ARTErrorInfo?) {
+    private func receiveErrorInfo(_ error: ARTErrorInfo?) {
         if let error = error {
-            failureCallback?(error.message)
+            logger.error("TCP Listener: \(error.message)")
         }
+    }
+    
+    private func receiveAuthError(_ reason: String) {
+        failureCallback?(reason)
+        closeChannel()
+    }
+    
+    private func openChannel() {
+        self.client = self.authenticator.getClient()
+        self.client.connection.on(.connected) { _ in
+            logger.log("TCP listen transport realtime client has connected")
+        }
+        self.client.connection.on(.disconnected) { _ in
+            logger.log("TCP listen transport realtime client has disconnected")
+        }
+        whisperChannel = client.channels.get(channelName)
+        whisperChannel?.on(.attached) { stateChange in
+            logger.log("TCP listen transport realtime client has attached the whisper channel")
+        }
+        whisperChannel?.on(.detached) { stateChange in
+            logger.log("TCP listen transport realtime client has detached the whisper channel")
+        }
+        whisperChannel?.attach()
+        whisperChannel?.subscribe(clientId, callback: receiveMessage)
+        whisperChannel?.subscribe("all", callback: receiveMessage)
+        whisperChannel?.presence.subscribe(receivePresence)
+        whisperChannel?.presence.enter(PreferenceData.userName())
+    }
+    
+    private func closeChannel() {
+        whisperChannel?.presence.leave(PreferenceData.userName())
+        whisperChannel?.detach()
+        whisperChannel = nil
+        client?.close()
+        client = nil
     }
     
     func receiveMessage(message: ARTMessage) {

--- a/whisper/Models/Transports/Tcp/TcpListenTransport.swift
+++ b/whisper/Models/Transports/Tcp/TcpListenTransport.swift
@@ -24,7 +24,7 @@ final class TcpListenTransport: SubscribeTransport {
     
     func stop() {
         logger.info("Stopping TCP listen transport")
-        whisperChannel?.detach()
+        closeChannel()
     }
     
     func goToBackground() {
@@ -182,8 +182,8 @@ final class TcpListenTransport: SubscribeTransport {
                 logger.warning("Ignoring leave event for non-candidate \(remoteId)")
                 return
             }
+            logger.info("The whisperer has left the building")
             dropRemoteSubject.send(remote)
-            failureCallback?("The whisperer disconnected")
         case .update:
             guard let candidate = candidates[remoteId] else {
                 logger.warning("Ignoring update event for non-candidate \(remoteId)")

--- a/whisper/Models/Transports/Tcp/TcpWhisperTransport.swift
+++ b/whisper/Models/Transports/Tcp/TcpWhisperTransport.swift
@@ -90,12 +90,14 @@ final class TcpWhisperTransport: PublishTransport {
     //MARK: Internal methods
     private func receiveErrorInfo(_ error: ARTErrorInfo?) {
         if let error = error {
-            failureCallback?(error.message)
+            logger.error("TCP Send/Receive Error: \(error.message)")
+            PreferenceData.tcpErrorCount += 1
         }
     }
     
     private func receiveAuthError(_ reason: String) {
         failureCallback?(reason)
+        PreferenceData.authenticationErrorCount += 1
         closeChannel()
     }
     

--- a/whisper/Settings.bundle/Root.plist
+++ b/whisper/Settings.bundle/Root.plist
@@ -40,6 +40,16 @@
 		</dict>
 		<dict>
 			<key>Type</key>
+			<string>PSToggleSwitchSpecifier</string>
+			<key>Title</key>
+			<string>Listener layout matches whisperer</string>
+			<key>Key</key>
+			<string>listener_matches_whisperer_preference</string>
+			<key>DefaultValue</key>
+			<false/>
+		</dict>
+		<dict>
+			<key>Type</key>
 			<string>PSMultiValueSpecifier</string>
 			<key>Title</key>
 			<string>Alert Sound</string>

--- a/whisper/Views/ListenView/ListenView.swift
+++ b/whisper/Views/ListenView/ListenView.swift
@@ -48,9 +48,8 @@ struct ListenView: View {
                     .popover(isPresented: $model.showStatusDetail) {
                         WhisperersView(model: model)
                     }
-                PastTextView(mode: mode, model: model.pastText)
+                PastTextView(model: model.pastText)
                     .font(FontSizes.fontFor(size))
-                    .textSelection(.enabled)
                     .foregroundColor(colorScheme == .light ? lightPastTextColor : darkPastTextColor)
                     .padding(innerPad)
                     .frame(maxWidth: geometry.size.width,
@@ -59,6 +58,7 @@ struct ListenView: View {
                     .border(colorScheme == .light ? lightPastBorderColor : darkPastBorderColor, width: 2)
                     .padding(EdgeInsets(top: 0, leading: sidePad, bottom: listenViewBottomPad, trailing: sidePad))
                     .dynamicTypeSize(magnify ? .accessibility3 : dynamicTypeSize)
+                    .textSelection(.enabled)
             }
             .multilineTextAlignment(.leading)
             .lineLimit(nil)

--- a/whisper/Views/ListenView/ListenView.swift
+++ b/whisper/Views/ListenView/ListenView.swift
@@ -63,10 +63,10 @@ struct ListenView: View {
             .multilineTextAlignment(.leading)
             .lineLimit(nil)
         }
-        .alert("Communication Error", isPresented: $model.connectionError) {
+        .alert("Connection Failure", isPresented: $model.connectionError) {
             Button("OK") { mode = .ask }
         } message: {
-            Text(model.connectionErrorDescription)
+            Text("Unable to establish a connection, please try again.\n(Detailed error: \(self.model.connectionErrorDescription)")
         }
         .onAppear {
             logger.log("ListenView appeared")

--- a/whisper/Views/ListenView/ListenView.swift
+++ b/whisper/Views/ListenView/ListenView.swift
@@ -18,6 +18,9 @@ struct ListenView: View {
     @State private var size = FontSizes.FontName.normal.rawValue
     @State private var magnify: Bool = false
     
+    // set this once at view creation
+    private var listenerLiveTextOnTop = !PreferenceData.listenerMatchesWhisperer()
+    
     init(mode: Binding<OperatingMode>, publisherUrl: TransportUrl) {
         self._mode = mode
         self.publisherUrl = publisherUrl
@@ -29,18 +32,32 @@ struct ListenView: View {
             VStack(spacing: 10) {
                 ControlView(size: $size, magnify: $magnify, mode: $mode, speaking: $model.speaking)
                     .padding(EdgeInsets(top: listenViewTopPad, leading: sidePad, bottom: 0, trailing: sidePad))
-                Text(model.liveText)
-                    .font(FontSizes.fontFor(size))
-                    .truncationMode(.head)
-                    .textSelection(.enabled)
-                    .foregroundColor(colorScheme == .light ? lightLiveTextColor : darkLiveTextColor)
-                    .padding(innerPad)
-                    .frame(maxWidth: geometry.size.width,
-                           maxHeight: geometry.size.height * liveTextProportion,
-                           alignment: .topLeading)
-                    .border(colorScheme == .light ? lightLiveBorderColor : darkLiveBorderColor, width: 2)
-                    .padding(EdgeInsets(top: 0, leading: sidePad, bottom: 0, trailing: sidePad))
-                    .dynamicTypeSize(magnify ? .accessibility3 : dynamicTypeSize)
+                if (listenerLiveTextOnTop) {
+                    Text(model.liveText)
+                        .font(FontSizes.fontFor(size))
+                        .truncationMode(.head)
+                        .textSelection(.enabled)
+                        .foregroundColor(colorScheme == .light ? lightLiveTextColor : darkLiveTextColor)
+                        .padding(innerPad)
+                        .frame(maxWidth: geometry.size.width,
+                               maxHeight: geometry.size.height * liveTextProportion,
+                               alignment: .topLeading)
+                        .border(colorScheme == .light ? lightLiveBorderColor : darkLiveBorderColor, width: 2)
+                        .padding(EdgeInsets(top: 0, leading: sidePad, bottom: 0, trailing: sidePad))
+                        .dynamicTypeSize(magnify ? .accessibility3 : dynamicTypeSize)
+                } else {
+                    PastTextView(mode: .listen, model: model.pastText)
+                        .font(FontSizes.fontFor(size))
+                        .foregroundColor(colorScheme == .light ? lightPastTextColor : darkPastTextColor)
+                        .padding(innerPad)
+                        .frame(maxWidth: geometry.size.width,
+                               maxHeight: geometry.size.height * pastTextProportion,
+                               alignment: .bottomLeading)
+                        .border(colorScheme == .light ? lightPastBorderColor : darkPastBorderColor, width: 2)
+                        .padding(EdgeInsets(top: 0, leading: sidePad, bottom: listenViewBottomPad, trailing: sidePad))
+                        .dynamicTypeSize(magnify ? .accessibility3 : dynamicTypeSize)
+                        .textSelection(.enabled)
+                }
                 StatusTextView(text: $model.statusText, publisherUrl: nil)
                     .onTapGesture {
                         model.showStatusDetail = true
@@ -48,17 +65,32 @@ struct ListenView: View {
                     .popover(isPresented: $model.showStatusDetail) {
                         WhisperersView(model: model)
                     }
-                PastTextView(model: model.pastText)
-                    .font(FontSizes.fontFor(size))
-                    .foregroundColor(colorScheme == .light ? lightPastTextColor : darkPastTextColor)
-                    .padding(innerPad)
-                    .frame(maxWidth: geometry.size.width,
-                           maxHeight: geometry.size.height * pastTextProportion,
-                           alignment: .bottomLeading)
-                    .border(colorScheme == .light ? lightPastBorderColor : darkPastBorderColor, width: 2)
-                    .padding(EdgeInsets(top: 0, leading: sidePad, bottom: listenViewBottomPad, trailing: sidePad))
-                    .dynamicTypeSize(magnify ? .accessibility3 : dynamicTypeSize)
-                    .textSelection(.enabled)
+                if (!listenerLiveTextOnTop) {
+                    Text(model.liveText)
+                        .font(FontSizes.fontFor(size))
+                        .truncationMode(.head)
+                        .textSelection(.enabled)
+                        .foregroundColor(colorScheme == .light ? lightLiveTextColor : darkLiveTextColor)
+                        .padding(innerPad)
+                        .frame(maxWidth: geometry.size.width,
+                               maxHeight: geometry.size.height * liveTextProportion,
+                               alignment: .topLeading)
+                        .border(colorScheme == .light ? lightLiveBorderColor : darkLiveBorderColor, width: 2)
+                        .padding(EdgeInsets(top: 0, leading: sidePad, bottom: 0, trailing: sidePad))
+                        .dynamicTypeSize(magnify ? .accessibility3 : dynamicTypeSize)
+                } else {
+                    PastTextView(mode: .listen, model: model.pastText)
+                        .font(FontSizes.fontFor(size))
+                        .foregroundColor(colorScheme == .light ? lightPastTextColor : darkPastTextColor)
+                        .padding(innerPad)
+                        .frame(maxWidth: geometry.size.width,
+                               maxHeight: geometry.size.height * pastTextProportion,
+                               alignment: .bottomLeading)
+                        .border(colorScheme == .light ? lightPastBorderColor : darkPastBorderColor, width: 2)
+                        .padding(EdgeInsets(top: 0, leading: sidePad, bottom: listenViewBottomPad, trailing: sidePad))
+                        .dynamicTypeSize(magnify ? .accessibility3 : dynamicTypeSize)
+                        .textSelection(.enabled)
+                }
             }
             .multilineTextAlignment(.leading)
             .lineLimit(nil)

--- a/whisper/Views/ListenView/ListenViewModel.swift
+++ b/whisper/Views/ListenView/ListenViewModel.swift
@@ -20,7 +20,7 @@ final class ListenViewModel: ObservableObject {
     @Published var showStatusDetail: Bool = false
     @Published var candidates: [Remote] = []
     @Published var whisperer: Remote?
-    @Published var pastText: PastTextViewModel = .init()
+    @Published var pastText: PastTextViewModel = .init(mode: .listen)
     
     private var transport: Transport
     private var manualWhisperer: Bool

--- a/whisper/Views/MainView/ChoiceView.swift
+++ b/whisper/Views/MainView/ChoiceView.swift
@@ -67,73 +67,62 @@ struct ChoiceView: View {
                 .cornerRadius(15)
                 .disabled(currentUserName == "")
             }
-            if PreferenceData.paidReceiptId() != nil {
-                HStack(spacing: 30) {
-                    VStack {
-                        Button(action: {
-                            publisherUrl = ComboFactory.shared.publisherUrl
-                            confirmWhisper = true
-                        }) {
-                            Text("Whisper \(Image(systemName: "network"))")
-                                .foregroundColor(.white)
-                                .fontWeight(.bold)
-                                .allowsTightening(true)
-                                .frame(width: choiceButtonWidth, height: choiceButtonHeight, alignment: .center)
-                        }
-                        .background(currentUserName == "" ? Color.gray : Color.accentColor)
-                        .cornerRadius(15)
-                        .disabled(currentUserName == "")
-                        ShareLink("URL", item: URL(string: ComboFactory.shared.publisherUrl!)!)
+            HStack(spacing: 30) {
+                VStack {
+                    Button(action: {
+                        publisherUrl = ComboFactory.shared.publisherUrl
+                        confirmWhisper = true
+                    }) {
+                        Text("Whisper \(Image(systemName: "network"))")
+                            .foregroundColor(.white)
+                            .fontWeight(.bold)
+                            .allowsTightening(true)
+                            .frame(width: choiceButtonWidth, height: choiceButtonHeight, alignment: .center)
                     }
-                    VStack {
-                        Button(action: {
-                            publisherUrl = lastSubscribedUrl
-                            confirmListen = true
-                        }) {
-                            Text("Listen \(Image(systemName: "network"))")
-                                .foregroundColor(.white)
-                                .fontWeight(.bold)
-                                .allowsTightening(true)
-                                .frame(width: choiceButtonWidth, height: choiceButtonHeight, alignment: .center)
-                        }
-                        .background(Color.accentColor)
-                        .cornerRadius(15)
-                        .disabled(currentUserName == "" || lastSubscribedUrl == nil)
-                        Button("\(Image(systemName: "square.and.arrow.down")) URL") {
-                            if UIPasteboard.general.hasStrings,
-                               let url = UIPasteboard.general.string
-                            {
-                                if PreferenceData.publisherUrlToClientId(url: url) != nil {
-                                    PreferenceData.lastSubscriberUrl = url
-                                    lastSubscribedUrl = url
-                                } else {
-                                    lastSubscribedUrl = nil
-                                }
+                    .background(currentUserName == "" ? Color.gray : Color.accentColor)
+                    .cornerRadius(15)
+                    .disabled(currentUserName == "")
+                    ShareLink("URL", item: URL(string: ComboFactory.shared.publisherUrl!)!)
+                }
+                VStack {
+                    Button(action: {
+                        publisherUrl = lastSubscribedUrl
+                        confirmListen = true
+                    }) {
+                        Text("Listen \(Image(systemName: "network"))")
+                            .foregroundColor(.white)
+                            .fontWeight(.bold)
+                            .allowsTightening(true)
+                            .frame(width: choiceButtonWidth, height: choiceButtonHeight, alignment: .center)
+                    }
+                    .background(Color.accentColor)
+                    .cornerRadius(15)
+                    .disabled(currentUserName == "" || lastSubscribedUrl == nil)
+                    Button("\(Image(systemName: "square.and.arrow.down")) URL") {
+                        if UIPasteboard.general.hasStrings,
+                           let url = UIPasteboard.general.string
+                        {
+                            if PreferenceData.publisherUrlToClientId(url: url) != nil {
+                                PreferenceData.lastSubscriberUrl = url
+                                lastSubscribedUrl = url
+                            } else {
+                                lastSubscribedUrl = nil
                             }
                         }
                     }
                 }
-                .alert("Confirm Internet Whisper", isPresented: $confirmWhisper) {
-                    Button("Whisper") { mode = .whisper }
-                    Button("Don't Whisper") { }
-                } message: {
-                    Text("Send your listeners the link with the share button")
-                }
-                .alert("Confirm Internet Listen", isPresented: $confirmListen) {
-                    Button("Listen") { mode = .listen }
-                    Button("Don't Listen") { }
-                } message: {
-                    Text("This will connect to the last received whisperer link")
-                }
-            } else {
-                Button(action: { }) {
-                    Text("Upgrade to \(Image(systemName: "network"))")
-                        .foregroundColor(.white)
-                        .fontWeight(.bold)
-                        .frame(width: choiceButtonWidth, height: choiceButtonHeight, alignment: .center)
-                }
-                .background(Color.accentColor)
-                .cornerRadius(15)
+            }
+            .alert("Confirm Internet Whisper", isPresented: $confirmWhisper) {
+                Button("Whisper") { mode = .whisper }
+                Button("Don't Whisper") { }
+            } message: {
+                Text("Send your listeners the link with the share button")
+            }
+            .alert("Confirm Internet Listen", isPresented: $confirmListen) {
+                Button("Listen") { mode = .listen }
+                Button("Don't Listen") { }
+            } message: {
+                Text("This will connect to the last received whisperer link")
             }
             Button(action: {
                 UIApplication.shared.open(settingsUrl)

--- a/whisper/Views/PastTextView/PastTextView.swift
+++ b/whisper/Views/PastTextView/PastTextView.swift
@@ -6,7 +6,6 @@
 import SwiftUI
 
 struct PastTextView: View {
-    var mode: OperatingMode
     @ObservedObject var model: PastTextViewModel
 
     var body: some View {
@@ -14,40 +13,57 @@ struct PastTextView: View {
             ScrollViewReader { sp in
                 ScrollView(.vertical, showsIndicators: true) {
                     VStack(alignment: .leading) {
-                        Spacer()
-                        ForEach(mode == .listen ? model.pastText.reversed() : model.pastText) {
-                            Text($0.text)
-                                .id($0.id)
+                        if !model.addLinesAtTop {
+                            Spacer()
+                                .id(0)
+                        }
+                        Text(model.pastText)
+                            .lineLimit(nil)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .id(1)
+                        if model.addLinesAtTop {
+                            Spacer()
+                                .id(2)
                         }
                     }
                     .frame(minWidth: gp.size.width, minHeight: gp.size.height, alignment: .leading)
                 }
                 .onAppear { self.scrollToEnd(sp) }
-                .onChange(of: model.pastText.count) { _ in self.scrollToEnd(sp) }
+                .onChange(of: model.pastText) { _ in self.scrollToEnd(sp) }
             }
         }
+        .textSelection(.enabled)
     }
     
     func scrollToEnd(_ sp: ScrollViewProxy) {
-        if model.pastText.count > 0 {
-            if mode == .listen {
-                sp.scrollTo(model.pastText.count - 1, anchor: .top)
-            } else {
-                sp.scrollTo(model.pastText.count - 1, anchor: .bottom)
-            }
+        if model.addLinesAtTop {
+            sp.scrollTo(1, anchor: .top)
+        } else {
+            sp.scrollTo(1, anchor: .bottom)
         }
     }
 }
 
 struct PastTextView_Previews: PreviewProvider {
-    static var model = PastTextViewModel(initialText: """
+    static var model1 = PastTextViewModel(mode: .whisper, initialText: """
     Line 1 is short
     Line 2 is a bit longer
     Line 3 is extremely, long and\nit wraps
     Line 4 is short
     """)
-    
+    static var model2 = PastTextViewModel(mode: .listen, initialText: """
+    Line 1 is short
+    Line 2 is a bit longer
+    Line 3 is extremely, long and\nit wraps
+    Line 4 is short
+    """)
+
     static var previews: some View {
-        PastTextView(mode: .listen, model: model)
+        VStack {
+            PastTextView(model: model1)
+                .border(.black, width: 2)
+            PastTextView(model: model2)
+                .border(.black, width: 2)
+        }
     }
 }

--- a/whisper/Views/PastTextView/PastTextView.swift
+++ b/whisper/Views/PastTextView/PastTextView.swift
@@ -17,9 +17,7 @@ struct PastTextView: View {
                             Spacer()
                                 .id(0)
                         }
-                        Text(model.pastText)
-                            .lineLimit(nil)
-                            .fixedSize(horizontal: false, vertical: true)
+                        TextEditor(text: $model.pastText)
                             .id(1)
                         if model.addLinesAtTop {
                             Spacer()

--- a/whisper/Views/PastTextView/PastTextViewModel.swift
+++ b/whisper/Views/PastTextView/PastTextViewModel.swift
@@ -11,37 +11,44 @@ struct PastTextLine: Identifiable {
 }
 
 final class PastTextViewModel: ObservableObject {
-    @Published var pastText: [PastTextLine]
+    @Published private(set) var pastText: String
+    @Published private(set) var addLinesAtTop = false
     
-    init() {
-        self.pastText = []
-    }
-    
-    init(initialText: String) {
-        self.pastText = []
-        self.setFromText(initialText)
-    }
-    
-    func getLines() -> [String] {
-        return pastText.map({ $0.text })
+    init(mode: OperatingMode, initialText: String = "") {
+        if mode == .listen {
+            addLinesAtTop = true
+        }
+        self.pastText = initialText
     }
     
     func addLine(_ line: String) {
-        pastText.append(PastTextLine(text: line, id: pastText.count))
-    }
-    
-    func clearLines() {
-        pastText = []
-    }
-    
-    func setFromText(_ text: String) {
-        pastText = []
-        for line in text.split(separator: "\n", omittingEmptySubsequences: false) {
-            pastText.append(PastTextLine(text: String(line), id: pastText.count))
+        if addLinesAtTop {
+            pastText = line + "\n" + pastText
+        } else {
+            pastText += "\n" + line
         }
     }
     
-    func getAsText() -> String {
-        return pastText.map({ $0.text }).joined(separator: "\n")
+    func clearLines() {
+        pastText = ""
+    }
+    
+    func getLines() -> [String] {
+        var lines = pastText.split(separator: "\n", omittingEmptySubsequences: false)
+        if addLinesAtTop {
+            lines.reverse()
+        }
+        return lines.map{ String($0) }
+    }
+    
+    func addText(_ text: String) {
+        for line in text.split(separator: "\n", omittingEmptySubsequences: false) {
+            addLine(String(line))
+        }
+    }
+    
+    func setFromText(_ text: String) {
+        clearLines()
+        addText(text)
     }
 }

--- a/whisper/Views/PastTextView/PastTextViewModel.swift
+++ b/whisper/Views/PastTextView/PastTextViewModel.swift
@@ -11,7 +11,7 @@ struct PastTextLine: Identifiable {
 }
 
 final class PastTextViewModel: ObservableObject {
-    @Published private(set) var pastText: String
+    @Published var pastText: String
     @Published private(set) var addLinesAtTop = false
     
     init(mode: OperatingMode, initialText: String = "") {

--- a/whisper/Views/PastTextView/PastTextViewModel.swift
+++ b/whisper/Views/PastTextView/PastTextViewModel.swift
@@ -15,7 +15,7 @@ final class PastTextViewModel: ObservableObject {
     @Published private(set) var addLinesAtTop = false
     
     init(mode: OperatingMode, initialText: String = "") {
-        if mode == .listen {
+        if mode == .listen && !PreferenceData.listenerMatchesWhisperer() {
             addLinesAtTop = true
         }
         self.pastText = initialText

--- a/whisper/Views/WhisperView/WhisperView.swift
+++ b/whisper/Views/WhisperView/WhisperView.swift
@@ -31,7 +31,7 @@ struct WhisperView: View {
             VStack(spacing: 10) {
                 ControlView(size: $size, magnify: $magnify, mode: $mode, speaking: $model.speaking, playSound: model.playSound)
                     .padding(EdgeInsets(top: whisperViewTopPad, leading: sidePad, bottom: 0, trailing: sidePad))
-                PastTextView(mode: mode, model: model.pastText)
+                PastTextView(model: model.pastText)
                     .font(FontSizes.fontFor(size))
                     .textSelection(.enabled)
                     .foregroundColor(colorScheme == .light ? lightPastTextColor : darkPastTextColor)

--- a/whisper/Views/WhisperView/WhisperView.swift
+++ b/whisper/Views/WhisperView/WhisperView.swift
@@ -75,6 +75,11 @@ struct WhisperView: View {
             .multilineTextAlignment(.leading)
             .lineLimit(nil)
         }
+        .alert("Connection Failure", isPresented: $model.connectionError) {
+            Button("OK") { mode = .ask }
+        } message: {
+            Text("Unable to establish a connection, please try again.\n(Detailed error: \(self.model.connectionErrorDescription)")
+        }
         .onAppear {
             logger.log("WhisperView appeared")
             self.model.start()

--- a/whisper/Views/WhisperView/WhisperView.swift
+++ b/whisper/Views/WhisperView/WhisperView.swift
@@ -31,7 +31,7 @@ struct WhisperView: View {
             VStack(spacing: 10) {
                 ControlView(size: $size, magnify: $magnify, mode: $mode, speaking: $model.speaking, playSound: model.playSound)
                     .padding(EdgeInsets(top: whisperViewTopPad, leading: sidePad, bottom: 0, trailing: sidePad))
-                PastTextView(model: model.pastText)
+                PastTextView(mode: .whisper, model: model.pastText)
                     .font(FontSizes.fontFor(size))
                     .textSelection(.enabled)
                     .foregroundColor(colorScheme == .light ? lightPastTextColor : darkPastTextColor)

--- a/whisper/Views/WhisperView/WhisperViewModel.swift
+++ b/whisper/Views/WhisperView/WhisperViewModel.swift
@@ -16,7 +16,7 @@ final class WhisperViewModel: ObservableObject {
     @Published var connectionErrorDescription: String = ""
     @Published var remotes: [String:Remote] = [:]
     @Published var speaking: Bool = PreferenceData.startSpeaking()
-    @Published var pastText: PastTextViewModel = .init()
+    @Published var pastText: PastTextViewModel = .init(mode: .whisper)
 
     private var transport: Transport
     private var cancellables: Set<AnyCancellable> = []

--- a/whisper/Views/WhisperView/WhisperViewModel.swift
+++ b/whisper/Views/WhisperView/WhisperViewModel.swift
@@ -156,14 +156,13 @@ final class WhisperViewModel: ObservableObject {
         refreshStatusText()
     }
 
-    // send all the text to a specific listener who requests it
+    // send live text to a specific listener who requests it
     private func sendAllText(_ pair: (remote: Remote, chunk: TextProtocol.ProtocolChunk)) {
         guard let remote = remotes[pair.remote.id] else {
             logger.warning("Read requested by unknown remote \(pair.remote.id)")
             return
         }
-        var chunks = pastText.getLines().map{TextProtocol.ProtocolChunk.fromPastText(text: $0)}
-        chunks.append(TextProtocol.ProtocolChunk.fromLiveText(text: liveText))
+        let chunks = [TextProtocol.ProtocolChunk.fromLiveText(text: liveText)]
         transport.send(remote: remote, chunks: chunks)
     }
     

--- a/whisper/whisperApp.swift
+++ b/whisper/whisperApp.swift
@@ -36,8 +36,9 @@ let lightPastBorderColor = Color(.darkGray)
 let darkPastBorderColor = Color(.lightGray)
 
 /// global constants for relative view sizes
-let pastTextProportion = 4.0/5.0
-let liveTextProportion = 1.0/5.0
+let liveTextFifths = UIDevice.current.userInterfaceIdiom == .phone ? 2.0 : 1.0
+let pastTextProportion = (5.0 - liveTextFifths)/5.0
+let liveTextProportion = liveTextFifths/5.0
 
 /// global constants for platform differentiation
 #if targetEnvironment(macCatalyst)


### PR DESCRIPTION
Robustness and other fixes for builds 32 (internal) & 33 (external):

1. Listeners don't stop when they disconnect from a whisperer.  Instead they try to reconnect.  So connections are much more stable.
2. When a listener connects to a whisperer, they don't get any of the whisperer's past text, just the current live text (if any).
3. The whisperer can edit all their past text, and can copy and paste it.
4. Listeners cannot edit or copy past text (just like a conversation).
5. Listeners can choose whether they want live text on the top (as it has been) or on the bottom (the way the whisperer sees it).
6. Collect diagnostic error counts from non-fatal communication errors and send them to server.