### PR TITLE
Next public release

### DIFF
--- a/Test Flight Release Notes.txt
+++ b/Test Flight Release Notes.txt
@@ -62,3 +62,20 @@ This build introduces several changes:
 5. Listeners can choose whether they want live text on the top (as it has been) or on the bottom (the way the whisperer sees it).
 
 NOTE: If you get a message when internet whispering about not being able to authenticate, try quitting and restarting the app.  If that doesn't work, delete and then reinstall the app.
+
+BUILDS 34 (internal) & 35 (external):
+Another cosmetic improvement and bug fix release:
+
+1. Ensure past text scrolls correctly (so the most recent line is always visible).
+
+2. For the listener, past text is never selectable (so it can't be copied).
+
+3. For the whisperer past text is not selectable by default, so accidental clicks don't shift focus to that area.  But the whisperer can explicitly start and end edit sessions over past text, in case they want to copy and paste portions into the live text area.
+
+4. The preferences have been revamped to be more useful and more understandable:
+
+    a. You can no longer set your name in the preferences (because you can do that in the app), but you can now choose not to remember your name from session to session (for use on shared devices).
+    b. The app now always starts with the choice screen (no preference for starting as a listener or a whisperer).
+    c. The listener can now choose whether they want the live text window on top or bottom of the screen.
+
+5. The whisperer can now change the alert sound while in a session.  Long-pressing the alert button brings up a menu of the available sounds.

--- a/Test Flight Release Notes.txt
+++ b/Test Flight Release Notes.txt
@@ -63,14 +63,14 @@ This build introduces several changes:
 
 NOTE: If you get a message when internet whispering about not being able to authenticate, try quitting and restarting the app.  If that doesn't work, delete and then reinstall the app.
 
-BUILDS 34 (internal) & 35 (external):
+BUILD 35 (external):
 Another cosmetic improvement and bug fix release:
 
-1. Ensure past text scrolls correctly (so the most recent line is always visible).
+1. Past text should now scroll correctly (so the most recent line is always visible).
 
 2. For the listener, past text is never selectable (so it can't be copied).
 
-3. For the whisperer past text is not selectable by default, so accidental clicks don't shift focus to that area.  But the whisperer can explicitly start and end edit sessions over past text, in case they want to copy and paste portions into the live text area.
+3. For the whisperer, past text is not selectable by default, so accidental clicks don't shift focus to that area.  But the whisperer can explicitly start and end edit sessions over past text, in case they want to copy and paste portions into the live text area.
 
 4. The preferences have been revamped to be more useful and more understandable:
 
@@ -79,3 +79,5 @@ Another cosmetic improvement and bug fix release:
     c. The listener can now choose whether they want the live text window on top or bottom of the screen.
 
 5. The whisperer can now change the alert sound while in a session.  Long-pressing the alert button brings up a menu of the available sounds.
+
+6. When there is only one listener, the whisper status text shows their name.

--- a/whisper.xcodeproj/project.pbxproj
+++ b/whisper.xcodeproj/project.pbxproj
@@ -725,7 +725,7 @@
 				CODE_SIGN_ENTITLEMENTS = whisper/whisper.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 34;
+				CURRENT_PROJECT_VERSION = 35;
 				DEVELOPMENT_ASSET_PATHS = "\"whisper/Preview Content\"";
 				DEVELOPMENT_TEAM = 9BJ65G9LZ5;
 				ENABLE_PREVIEWS = YES;
@@ -766,7 +766,7 @@
 				CODE_SIGN_ENTITLEMENTS = whisper/whisper.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 34;
+				CURRENT_PROJECT_VERSION = 35;
 				DEVELOPMENT_ASSET_PATHS = "\"whisper/Preview Content\"";
 				DEVELOPMENT_TEAM = 9BJ65G9LZ5;
 				ENABLE_PREVIEWS = YES;

--- a/whisper.xcodeproj/project.pbxproj
+++ b/whisper.xcodeproj/project.pbxproj
@@ -725,7 +725,7 @@
 				CODE_SIGN_ENTITLEMENTS = whisper/whisper.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 32;
+				CURRENT_PROJECT_VERSION = 34;
 				DEVELOPMENT_ASSET_PATHS = "\"whisper/Preview Content\"";
 				DEVELOPMENT_TEAM = 9BJ65G9LZ5;
 				ENABLE_PREVIEWS = YES;
@@ -766,7 +766,7 @@
 				CODE_SIGN_ENTITLEMENTS = whisper/whisper.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 32;
+				CURRENT_PROJECT_VERSION = 34;
 				DEVELOPMENT_ASSET_PATHS = "\"whisper/Preview Content\"";
 				DEVELOPMENT_TEAM = 9BJ65G9LZ5;
 				ENABLE_PREVIEWS = YES;

--- a/whisper/Models/PreferenceData.swift
+++ b/whisper/Models/PreferenceData.swift
@@ -12,6 +12,8 @@ enum OperatingMode: Int {
 
 struct PreferenceData {
     private static var defaults = UserDefaults.standard
+    
+    // publisher URLs
     #if DEBUG
     static var whisperServer = "https://stage.whisper.clickonetwo.io"
     #else
@@ -24,6 +26,8 @@ struct PreferenceData {
         }
         return String(match.2)
     }
+    
+    // client IDs for TCP transport
     static var clientId: String = {
         if let id = defaults.string(forKey: "whisper_client_id") {
             return id
@@ -33,9 +37,9 @@ struct PreferenceData {
             return id
         }
     }()
-    static func listenerMatchesWhisperer() -> Bool {
-        return defaults.string(forKey: "newest_whisper_location_preference") == "bottom"
-    }
+    
+    // client secrets for TCP transport
+    //
     // Secrets rotate.  The client generates its first secret, and always
     // sets that as both the current and prior secret.  After that, every
     // time the server sends a new secret, the current secret rotates to
@@ -78,9 +82,18 @@ struct PreferenceData {
         }
         return Data(bytes).base64EncodedString()
     }
+    
+    // layout control of listeners
+    static func listenerMatchesWhisperer() -> Bool {
+        return defaults.string(forKey: "newest_whisper_location_preference") == "bottom"
+    }
+    
+    // whether to speak past text
     static func startSpeaking() -> Bool {
         return defaults.bool(forKey: "read_aloud_preference")
     }
+    
+    // user name and session memory
     private static var session_name: String = ""
     static func userName() -> String {
         var name = session_name
@@ -104,13 +117,33 @@ struct PreferenceData {
             defaults.setValue(name, forKey: "session_name")
         }
     }
+    
+    // require Bluetooth listeners to pair?
     static func requireAuthentication() -> Bool {
         let result = defaults.bool(forKey: "listener_authentication_preference")
         return result
     }
-    static func alertSound() -> String {
-        return defaults.string(forKey: "alert_sound_preference") ?? "bike-horn"
+    
+    // alert sounds
+    struct AlertSoundChoice: Identifiable {
+        var id: String
+        var name: String
     }
+    static let alertSoundChoices: [AlertSoundChoice] = [
+        AlertSoundChoice(id: "air-horn", name: "Air Horn"),
+        AlertSoundChoice(id: "bike-horn", name: "Bicycle Horn"),
+        AlertSoundChoice(id: "bike-bell", name: "Bicycle Bell"),
+    ]
+    static var alertSound: String {
+        get {
+            return defaults.string(forKey: "alert_sound_preference") ?? "bike-horn"
+        }
+        set(new) {
+            defaults.setValue(new, forKey: "alert_sound_preference")
+        }
+    }
+    
+    // last used listener URL
     static var lastSubscriberUrl: String? {
         get {
             defaults.string(forKey: "last_subscriber_url")
@@ -123,6 +156,8 @@ struct PreferenceData {
             }
         }
     }
+    
+    // metrics of errors to send in diagnostics to server
     static var droppedErrorCount: Int {
         get {
             defaults.integer(forKey: "dropped_error_count")

--- a/whisper/Settings.bundle/Root.plist
+++ b/whisper/Settings.bundle/Root.plist
@@ -8,21 +8,19 @@
 	<array>
 		<dict>
 			<key>Type</key>
-			<string>PSTextFieldSpecifier</string>
+			<string>PSToggleSwitchSpecifier</string>
 			<key>Title</key>
-			<string>Your name</string>
+			<string>Remember name from last session</string>
 			<key>Key</key>
-			<string>device_name_preference</string>
-			<key>AutocapitalizationType</key>
-			<string>Words</string>
-			<key>AutocorrectionType</key>
-			<string>No</string>
+			<string>remember_name_preference</string>
+			<key>DefaultValue</key>
+			<true/>
 		</dict>
 		<dict>
 			<key>Type</key>
 			<string>PSToggleSwitchSpecifier</string>
 			<key>Title</key>
-			<string>Require listeners to pair</string>
+			<string>Require Bluetooth listeners to pair</string>
 			<key>Key</key>
 			<string>listener_authentication_preference</string>
 			<key>DefaultValue</key>
@@ -40,13 +38,23 @@
 		</dict>
 		<dict>
 			<key>Type</key>
-			<string>PSToggleSwitchSpecifier</string>
+			<string>PSMultiValueSpecifier</string>
 			<key>Title</key>
-			<string>Listener layout matches whisperer</string>
+			<string>Listener sees newest whisper in</string>
 			<key>Key</key>
-			<string>listener_matches_whisperer_preference</string>
+			<string>newest_whisper_location_preference</string>
 			<key>DefaultValue</key>
-			<false/>
+			<string>top</string>
+			<key>Values</key>
+			<array>
+				<string>top</string>
+				<string>bottom</string>
+			</array>
+			<key>Titles</key>
+			<array>
+				<string>Top window</string>
+				<string>Bottom window</string>
+			</array>
 		</dict>
 		<dict>
 			<key>Type</key>
@@ -68,28 +76,6 @@
 				<string>air-horn</string>
 				<string>bike-horn</string>
 				<string>bike-bell</string>
-			</array>
-		</dict>
-		<dict>
-			<key>Type</key>
-			<string>PSMultiValueSpecifier</string>
-			<key>Title</key>
-			<string>Initial Mode</string>
-			<key>Key</key>
-			<string>initial_mode_preference</string>
-			<key>DefaultValue</key>
-			<real>0</real>
-			<key>Titles</key>
-			<array>
-				<string>Ask</string>
-				<string>Listen</string>
-				<string>Whisper</string>
-			</array>
-			<key>Values</key>
-			<array>
-				<integer>0</integer>
-				<integer>1</integer>
-				<integer>2</integer>
 			</array>
 		</dict>
 	</array>

--- a/whisper/Views/ControlView/ControlView.swift
+++ b/whisper/Views/ControlView/ControlView.swift
@@ -15,6 +15,7 @@ struct ControlView: View {
     var playSound: (() -> ())?
     
     @State var confirmDisconnect = false
+    @State var alertSound = PreferenceData.alertSound
 
     var body: some View {
         HStack(alignment: .center) {
@@ -56,16 +57,25 @@ struct ControlView: View {
         if mode == .listen {
             EmptyView()
         } else {
-            Button {
-                playSound?()
+            Menu {
+                ForEach(PreferenceData.alertSoundChoices) { choice in
+                    Button {
+                        alertSound = choice.id
+                        PreferenceData.alertSound = choice.id
+                    } label: {
+                        Label(choice.name, image: choice.id + "-icon")
+                    }
+                }
             } label: {
-                fontButtonImage(PreferenceData.alertSound() + "-icon", pad: 5)
+                buttonImage(alertSound + "-icon", pad: 5)
+            } primaryAction: {
+                playSound?()
             }
             Spacer()
         }
     }
 
-    private func fontButtonImage(_ name: String, pad: CGFloat = 0) -> some View {
+    private func buttonImage(_ name: String, pad: CGFloat = 0) -> some View {
         Image(name)
             .renderingMode(.template)
             .resizable()
@@ -81,13 +91,13 @@ struct ControlView: View {
             Button {
                 self.size = FontSizes.nextTextSmaller(self.size)
             } label: {
-                fontButtonImage("font-down-button")
+                buttonImage("font-down-button")
             }
             .disabled(size == FontSizes.minTextSize)
             Button {
                 self.size = FontSizes.nextTextLarger(self.size)
             } label: {
-                fontButtonImage("font-up-button")
+                buttonImage("font-up-button")
             }
             .disabled(size == FontSizes.maxTextSize)
             Spacer()

--- a/whisper/Views/ListenView/ListenViewModel.swift
+++ b/whisper/Views/ListenView/ListenViewModel.swift
@@ -232,7 +232,7 @@ final class ListenViewModel: ObservableObject {
         var path = Bundle.main.path(forResource: name, ofType: "caf")
         if path == nil {
             // try again with default sound
-            name = PreferenceData.alertSound()
+            name = PreferenceData.alertSound
             path = Bundle.main.path(forResource: name, ofType: "caf")
         }
         guard path != nil else {

--- a/whisper/Views/PastTextView/PastTextView.swift
+++ b/whisper/Views/PastTextView/PastTextView.swift
@@ -9,60 +9,87 @@ struct PastTextView: View {
     var mode: OperatingMode
     @ObservedObject var model: PastTextViewModel
     
-    
+    @FocusState private var isEditing: Bool
+    @State private var editing = false
     @State private var textEditorHeight : CGFloat = 20
 
     var body: some View {
         GeometryReader { gp in
-            ScrollViewReader { sp in
-                ScrollView(.vertical, showsIndicators: true) {
-                    VStack(alignment: .leading) {
-                        if !model.addLinesAtTop {
-                            Spacer()
-                                .id(0)
-                        }
-                        if mode == .listen {
-                            Text(model.pastText)
-                                .textSelection(.disabled)
-                                .lineLimit(nil)
-                                .fixedSize(horizontal: false, vertical: true)
+            ZStack {
+                ScrollViewReader { sp in
+                    ScrollView(.vertical, showsIndicators: true) {
+                        VStack(alignment: .leading) {
+                            if model.addLinesAtTop {
+                                HStack { Spacer() }.id(0)
+                            } else {
+                                Spacer().id(0)
+                            }
+                            if editing {
+                                ZStack {
+                                    Text(model.pastText)
+                                        .lineLimit(nil)
+                                        .fixedSize(horizontal: false, vertical: true)
+                                        .padding(5)
+                                        .foregroundColor(.clear)
+                                        .background(GeometryReader {
+                                            Color.clear.preference(key: ViewHeightKey.self,
+                                                                   value: $0.frame(in: .local).size.height)
+                                        })
+                                    TextEditor(text: $model.pastText)
+                                        .frame(height: textEditorHeight)
+                                        .focused($isEditing)
+                                }
+                                .onPreferenceChange(ViewHeightKey.self) { textEditorHeight = $0 }
                                 .id(1)
-                        } else {
-                            ZStack {
+                            } else {
                                 Text(model.pastText)
+                                    .textSelection(.disabled)
                                     .lineLimit(nil)
                                     .fixedSize(horizontal: false, vertical: true)
-                                    .padding(5)
-                                    .foregroundColor(.clear)
-                                    .background(GeometryReader {
-                                        Color.clear.preference(key: ViewHeightKey.self,
-                                                               value: $0.frame(in: .local).size.height)
-                                    })
-                                TextEditor(text: $model.pastText)
-                                    .frame(height: textEditorHeight)
+                                    .id(1)
                             }
-                            .onPreferenceChange(ViewHeightKey.self) { textEditorHeight = $0 }
-                            .id(1)
+                            if model.addLinesAtTop {
+                                Spacer().id(2)
+                            } else {
+                                HStack { Spacer() }.id(2)
+                            }
                         }
-                        if model.addLinesAtTop {
+                        .frame(minWidth: gp.size.width, minHeight: gp.size.height, alignment: .leading)
+                    }
+                    .onAppear { self.scrollToEnd(sp) }
+                    .onChange(of: model.pastText) { _ in self.scrollToEnd(sp) }
+                }
+                if mode == .whisper {
+                    VStack {
+                        Spacer()
+                        HStack {
                             Spacer()
-                                .id(2)
+                            Button(action: {
+                                editing.toggle()
+                                isEditing = editing
+                            }, label: {
+                                if editing {
+                                    Image(systemName: "pencil.slash")
+                                        .foregroundColor(.accentColor)
+                                        .background(Color(UIColor.systemBackground))
+                                } else {
+                                    Image(systemName: "pencil")
+                                        .foregroundColor(.accentColor)
+                                        .background(Color(UIColor.systemBackground))
+                                }
+                            })
                         }
                     }
-                    .frame(minWidth: gp.size.width, minHeight: gp.size.height, alignment: .leading)
                 }
-                .onAppear { self.scrollToEnd(sp) }
-                .onChange(of: model.pastText) { _ in self.scrollToEnd(sp) }
             }
         }
-        .textSelection(.enabled)
     }
     
     func scrollToEnd(_ sp: ScrollViewProxy) {
         if model.addLinesAtTop {
-            sp.scrollTo(1, anchor: .top)
+            sp.scrollTo(0, anchor: .top)
         } else {
-            sp.scrollTo(1, anchor: .bottom)
+            sp.scrollTo(2, anchor: .bottom)
         }
     }
 }

--- a/whisper/Views/WhisperView/WhisperViewModel.swift
+++ b/whisper/Views/WhisperView/WhisperViewModel.swift
@@ -202,7 +202,7 @@ final class WhisperViewModel: ObservableObject {
             return
         }
         if remotes.count == 1 {
-            statusText = "Whispering to 1 listener"
+            statusText = "Whispering to \(remotes.first!.value.name)"
         } else {
             statusText = "Whispering to \(remotes.count) listeners"
         }

--- a/whisper/Views/WhisperView/WhisperViewModel.swift
+++ b/whisper/Views/WhisperView/WhisperViewModel.swift
@@ -87,7 +87,7 @@ final class WhisperViewModel: ObservableObject {
     
     /// Play the alert sound to all the listeners
     func playSound() {
-        let soundName = PreferenceData.alertSound()
+        let soundName = PreferenceData.alertSound
         if speaking {
             playSoundLocally(soundName)
         }
@@ -101,7 +101,7 @@ final class WhisperViewModel: ObservableObject {
             logger.log("Ignoring alert request for non-remote: \(remote.id)")
             return
         }
-        let soundName = PreferenceData.alertSound()
+        let soundName = PreferenceData.alertSound
         let chunk = TextProtocol.ProtocolChunk.sound(soundName)
         transport.send(remote: remote, chunks: [chunk])
     }
@@ -178,7 +178,7 @@ final class WhisperViewModel: ObservableObject {
         var path = Bundle.main.path(forResource: name, ofType: "caf")
         if path == nil {
             // try again with default sound
-            name = PreferenceData.alertSound()
+            name = PreferenceData.alertSound
             path = Bundle.main.path(forResource: name, ofType: "caf")
         }
         guard path != nil else {

--- a/whisper/whisperApp.swift
+++ b/whisper/whisperApp.swift
@@ -70,7 +70,7 @@ let logger = Logger()
 @main
 struct whisperApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
-    @State var mode: OperatingMode = PreferenceData.initialMode()
+    @State var mode: OperatingMode = .ask
     @State var publisherUrl: TransportUrl = nil
     @State var showWarning: Bool = false
     @State var warningMessage: String = ""


### PR DESCRIPTION
BUILD 35 (external):
Another cosmetic improvement and bug fix release:

1. Past text should now scroll correctly (so the most recent line is always visible).

2. For the listener, past text is never selectable (so it can't be copied).

3. For the whisperer, past text is not selectable by default, so accidental clicks don't shift focus to that area.  But the whisperer can explicitly start and end edit sessions over past text, in case they want to copy and paste portions into the live text area.

4. The preferences have been revamped to be more useful and more understandable:

    a. You can no longer set your name in the preferences (because you can do that in the app), but you can now choose not to remember your name from session to session (for use on shared devices).
    b. The app now always starts with the choice screen (no preference for starting as a listener or a whisperer).
    c. The listener can now choose whether they want the live text window on top or bottom of the screen.

5. The whisperer can now change the alert sound while in a session.  Long-pressing the alert button brings up a menu of the available sounds.

6. When there is only one listener, the whisper status text shows their name.
