### PR TITLE
Drop background app refresh for build 41 (internal).

### DIFF
--- a/Test Flight Release Notes.txt
+++ b/Test Flight Release Notes.txt
@@ -110,3 +110,14 @@ This build makes preference changes recommended by the docs writer:
 - Make the in-session controls for reading whispers aloud be the only controls for it, and separate the whisper and listener values so they are remembered separately.
 
 - Reword the bluetooth pairing setting so it's clearer that it is controlled by the Whisperer.
+
+BUILD 41 (internal):
+This build makes preference changes recommended by the docs writer:
+
+- Make the whisper alert sound only changeable from the whisper view.
+
+- Make the in-session controls for reading whispers aloud be the only controls for it, and separate the whisper and listener values so they are remembered separately.
+
+- Reword the bluetooth pairing setting so it's clearer that it is controlled by the Whisperer.
+
+This build also drops the background app refresh capability, which is not needed.

--- a/whisper.xcodeproj/project.pbxproj
+++ b/whisper.xcodeproj/project.pbxproj
@@ -729,7 +729,7 @@
 				CODE_SIGN_ENTITLEMENTS = whisper/whisper.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 40;
+				CURRENT_PROJECT_VERSION = 41;
 				DEVELOPMENT_ASSET_PATHS = "\"whisper/Preview Content\"";
 				DEVELOPMENT_TEAM = 9BJ65G9LZ5;
 				ENABLE_PREVIEWS = YES;
@@ -770,7 +770,7 @@
 				CODE_SIGN_ENTITLEMENTS = whisper/whisper.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 40;
+				CURRENT_PROJECT_VERSION = 41;
 				DEVELOPMENT_ASSET_PATHS = "\"whisper/Preview Content\"";
 				DEVELOPMENT_TEAM = 9BJ65G9LZ5;
 				ENABLE_PREVIEWS = YES;

--- a/whisper/Info.plist
+++ b/whisper/Info.plist
@@ -15,7 +15,6 @@
 	<array>
 		<string>bluetooth-central</string>
 		<string>bluetooth-peripheral</string>
-		<string>remote-notification</string>
 	</array>
 	<key>UILaunchScreen</key>
 	<dict>


### PR DESCRIPTION
This build makes preference changes recommended by the docs writer:

- Make the whisper alert sound only changeable from the whisper view.

- Make the in-session controls for reading whispers aloud be the only controls for it, and separate the whisper and listener values so they are remembered separately.

- Reword the bluetooth pairing setting so it's clearer that it is controlled by the Whisperer.

This build also drops the background app refresh capability, which is not needed.