### PR TITLE
Conversation links now contain the name of the conversation.

### DIFF
--- a/Test Flight Release Notes.txt
+++ b/Test Flight Release Notes.txt
@@ -242,3 +242,8 @@ To test this, a Whisperer can listen to themselves from a browser using one name
 
 v2 BUILD 16 (external):
 This fixes the crash on launch after initial install problem that was introduced in build 2.0.0.10 (on Feb 26, 2024).  Sorry about that, new users!!
+
+v2 BUILD 17 (external):
+Starting with this build, the Share Links for conversations show the name of the conversation right after the conversation ID.  (The name has all non-letter, non-number characters replaced with '-' so the link is a valid URL.)
+
+For example, the link for "Conversation 1" might look like this: https://whisper.clickonetwo.io/listen/664ED54A-8DE4-4CF7-9427-0E83A1495BEE/Conversation-1

--- a/whisper.xcodeproj/project.pbxproj
+++ b/whisper.xcodeproj/project.pbxproj
@@ -763,7 +763,7 @@
 				CODE_SIGN_ENTITLEMENTS = whisper/whisper.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 16;
+				CURRENT_PROJECT_VERSION = 17;
 				DEVELOPMENT_ASSET_PATHS = "\"whisper/Preview Content\"";
 				DEVELOPMENT_TEAM = 9BJ65G9LZ5;
 				ENABLE_PREVIEWS = YES;
@@ -805,7 +805,7 @@
 				CODE_SIGN_ENTITLEMENTS = whisper/whisper.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 16;
+				CURRENT_PROJECT_VERSION = 17;
 				DEVELOPMENT_ASSET_PATHS = "\"whisper/Preview Content\"";
 				DEVELOPMENT_TEAM = 9BJ65G9LZ5;
 				ENABLE_PREVIEWS = YES;

--- a/whisper/Models/PreferenceData.swift
+++ b/whisper/Models/PreferenceData.swift
@@ -22,15 +22,23 @@ struct PreferenceData {
     static func publisherUrlToConversationId(url: String) -> String? {
 		let expectedPrefix = whisperServer + "/listen/"
 		if url.starts(with: expectedPrefix) {
-			let tail = url.suffix(36)
+			let tailEnd = url.index(expectedPrefix.endIndex, offsetBy: 36)
+			let tail = url[expectedPrefix.endIndex..<tailEnd]
 			if tail.wholeMatch(of: /[-a-zA-Z0-9]{36}/) != nil {
 				return String(tail)
 			}
 		}
         return nil
     }
-    static func publisherUrl(_ conversationId: String) -> String {
-        return "\(whisperServer)/listen/\(conversationId)"
+    static func publisherUrl(_ conversation: WhisperConversation) -> String {
+		let urlName = conversation.name.compactMap{char in
+			if char.isLetter || char.isNumber {
+				return String(char)
+			} else {
+				return "-"
+			}
+		}.joined()
+		return "\(whisperServer)/listen/\(conversation.id)/\(urlName)"
     }
     
     // server (and Ably) client ID for this device

--- a/whisper/Views/ProfileViews/WhisperProfileDetailView.swift
+++ b/whisper/Views/ProfileViews/WhisperProfileDetailView.swift
@@ -43,7 +43,7 @@ struct WhisperProfileDetailView: View {
 						updateConversation()
 					}
 				}
-				ShareLink("Listen link", item: PreferenceData.publisherUrl(conversation.id))
+				ShareLink("Listen link", item: PreferenceData.publisherUrl(conversation))
 			}
 			Section(header: allowedParticipants.isEmpty ? Text("No Allowed Participants") : Text("Allowed Participants")) {
 				List {

--- a/whisper/Views/StatusTextView/StatusTextView.swift
+++ b/whisper/Views/StatusTextView/StatusTextView.swift
@@ -13,8 +13,8 @@ struct StatusTextView: View {
 	var conversation: (any Conversation)?
 
 	private var shareLinkUrl: URL {
-		if let c = conversation {
-			return URL(string: PreferenceData.publisherUrl(c.id))!
+		if let c = conversation as? WhisperConversation {
+			return URL(string: PreferenceData.publisherUrl(c))!
 		} else {
 			return URL(string: "https://localhost")!
 		}


### PR DESCRIPTION
Because conversations can contain any letters, non-alpha-numerics are converted to '-', so for example "Conversation 1" becomes "Conversation-1".

Fixes #63.