### PR TITLE
Handle self-authorization for shared profiles.

### DIFF
--- a/Test Flight Release Notes.txt
+++ b/Test Flight Release Notes.txt
@@ -247,3 +247,10 @@ v2 BUILD 17 (external):
 Starting with this build, the Share Links for conversations show the name of the conversation right after the conversation ID.  (The name has all non-letter, non-number characters replaced with '-' so the link is a valid URL.)
 
 For example, the link for "Conversation 1" might look like this: https://whisper.clickonetwo.io/listen/664ED54A-8DE4-4CF7-9427-0E83A1495BEE/Conversation-1
+
+v2 BUILD 18 (external):
+The app now recognizes when a user is whispering to themself and automatically authorizes them to join the conversation. This allows people who use shared profiles to have one of their devices be dedicated to listening and have it always be able to listen to every conversation (including via local discovery) without ever being sent a link or using the "accept" UI.
+
+To support this, the view that shows all the conversations you have listened to now separates conversations sent you by others from conversations you own.  This allows you both to select one of the ones you own to listen to and it always shows all your conversations whether you have listened to it before or not.
+
+Users who don't use shared profiles won't notice any changes in this build.

--- a/whisper.xcodeproj/project.pbxproj
+++ b/whisper.xcodeproj/project.pbxproj
@@ -763,7 +763,7 @@
 				CODE_SIGN_ENTITLEMENTS = whisper/whisper.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 17;
+				CURRENT_PROJECT_VERSION = 18;
 				DEVELOPMENT_ASSET_PATHS = "\"whisper/Preview Content\"";
 				DEVELOPMENT_TEAM = 9BJ65G9LZ5;
 				ENABLE_PREVIEWS = YES;
@@ -805,7 +805,7 @@
 				CODE_SIGN_ENTITLEMENTS = whisper/whisper.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 17;
+				CURRENT_PROJECT_VERSION = 18;
 				DEVELOPMENT_ASSET_PATHS = "\"whisper/Preview Content\"";
 				DEVELOPMENT_TEAM = 9BJ65G9LZ5;
 				ENABLE_PREVIEWS = YES;

--- a/whisper/Extensions/Data+JSON.swift
+++ b/whisper/Extensions/Data+JSON.swift
@@ -72,27 +72,27 @@ extension Data {
 			}
 			if (response.statusCode >= 200 && response.statusCode < 300) {
 				if let data = data, data.count > 0 {
-					logger.info("Received \(response.statusCode) response with \(data.count) byte body")
+					// logger.info("Received \(response.statusCode) response with \(data.count) byte body")
 					handler?(response.statusCode, data)
 				} else {
-					logger.info("Received \(response.statusCode) response with empty body")
+					// logger.info("Received \(response.statusCode) response with empty body")
 					handler?(response.statusCode, Data())
 				}
 			} else {
 				if let data = data, data.count > 0 {
-					if let message = String(data: data, encoding: .utf8) {
-						logger.error("Received \(response.statusCode, privacy: .public) response with message: \(message, privacy: .public)")
-					} else {
-						logger.error("Received \(response.statusCode, privacy: .public) reponse with non-UTF8 body: \(String(describing: data), privacy: .public)")
-					}
+					// if let message = String(data: data, encoding: .utf8) {
+					// 	logger.error("Received \(response.statusCode, privacy: .public) response with message: \(message, privacy: .public)")
+					// } else {
+					// 	logger.error("Received \(response.statusCode, privacy: .public) reponse with non-UTF8 body: \(String(describing: data), privacy: .public)")
+					// }
 					handler?(response.statusCode, data)
 				} else {
-					logger.error("Received \(response.statusCode, privacy: .public) response with no body")
+					// logger.error("Received \(response.statusCode, privacy: .public) response with no body")
 					handler?(response.statusCode, Data())
 				}
 			}
 		}
-		logger.info("Executing \(request.httpMethod!) \(request.url!)")
+		// logger.info("Executing \(request.httpMethod!) \(request.url!)")
 		task.resume()
 	}
 }

--- a/whisper/Models/UserProfile/WhisperProfile.swift
+++ b/whisper/Models/UserProfile/WhisperProfile.swift
@@ -120,6 +120,10 @@ final class WhisperProfile: Codable {
 
 	/// add a user to a conversation and/or update their name in the conversation
 	func addListener(_ conversation: WhisperConversation, info: WhisperProtocol.ClientInfo) {
+		guard info.profileId != id else {
+			// we never add ourselves as a listener
+			return
+		}
 		if let username = conversation.allowed[info.profileId], username == info.username {
 			// nothing to do
 			return
@@ -214,6 +218,7 @@ final class WhisperProfile: Codable {
 			if code == 200,
 			   let profile = try? JSONDecoder().decode(WhisperProfile.self, from: data)
 			{
+				logger.info("Received updated whisper profile, timestamp is \(profile.timestamp)")
 				self.table = profile.table
 				self.defaultId = profile.defaultId
 				self.timestamp = profile.timestamp

--- a/whisper/Views/ListenView/ListenViewModel.swift
+++ b/whisper/Views/ListenView/ListenViewModel.swift
@@ -331,7 +331,9 @@ final class ListenViewModel: ObservableObject {
 		if let existing = candidates[remote.id] {
 			return existing
 		}
-		let candidate = Candidate(remote: remote, info: info, isPending: !conversation.authorized)
+		// we are always authorized to listen to our own conversations
+		let isPending = info.profileId == UserProfile.shared.id ? false : !conversation.authorized
+		let candidate = Candidate(remote: remote, info: info, isPending: isPending)
 		candidates[candidate.id] = candidate
 		return candidate
 	}

--- a/whisper/Views/MainView/ChoiceView.swift
+++ b/whisper/Views/MainView/ChoiceView.swift
@@ -174,7 +174,6 @@ struct ChoiceView: View {
 			Text("You must enable a Bluetooth and/or Wireless connection before you can whisper or listen")
 		}
 		.onChange(of: profile.timestamp, initial: true, updateFromProfile)
-		.onChange(of: scenePhase, initial: true, profile.update)
         .onChange(of: nameEdit) {
             if nameEdit {
                 withAnimation { showWhisperButtons = false }
@@ -182,6 +181,13 @@ struct ChoiceView: View {
                 updateOrRevertProfile()
             }
         }
+		.onChange(of: scenePhase) {
+			if scenePhase == .active {
+				logger.info("ChoiceView has become active")
+				profile.update()
+			}
+		}
+		.onAppear(perform: profile.update)
     }
     
     func updateFromProfile() {

--- a/whisper/Views/ProfileViews/ListenProfileView.swift
+++ b/whisper/Views/ProfileViews/ListenProfileView.swift
@@ -14,42 +14,57 @@ struct ListenProfileView: View {
 	var maybeListen: ((ListenConversation?) -> Void)?
 
     @State private var conversations: [ListenConversation] = []
+	@State private var myConversations: [WhisperConversation] = []
 	@StateObject private var profile = UserProfile.shared
 
     var body: some View {
 		NavigationStack {
-			VStack(alignment: .center, spacing: 20) {
+			VStack(alignment: .leading, spacing: 20) {
+				if (!myConversations.isEmpty) {
+					Text("Conversations with Others").font(.title3)
+				}
 				if (!conversations.isEmpty) {
-					VStack(alignment: .leading) {
-						ForEach(conversations) { c in
-							HStack(spacing: 10) {
-								Button("Listen", systemImage: "ear") {
-									logger.info("Hit listen button on \(c.id) (\(c.name))")
-									maybeListen?(c)
-								}
-								Text("\(c.name) with \(c.ownerName)").lineLimit(nil)
-								Spacer(minLength: 25)
-								Button("Delete", systemImage: "delete.left") {
-									logger.info("Hit delete button on \(c.id) (\(c.name))")
-									profile.listenProfile.delete(c.id)
-									updateFromProfile()
-								}
+					List(conversations) { c in
+						HStack(spacing: 10) {
+							Button("Listen", systemImage: "ear") {
+								logger.info("Hit listen button on \(c.id) (\(c.name))")
+								maybeListen?(c)
 							}
-							.labelStyle(.iconOnly)
-							.buttonStyle(.borderless)
+							Text("\(c.name) with \(c.ownerName)").lineLimit(nil)
+							Spacer(minLength: 25)
+							Button("Delete", systemImage: "delete.left") {
+								logger.info("Hit delete button on \(c.id) (\(c.name))")
+								profile.listenProfile.delete(c.id)
+								updateFromProfile()
+							}
 						}
-						Spacer()
+						.labelStyle(.iconOnly)
+						.buttonStyle(.borderless)
 					}
 				} else {
-					Text("(No past conversations)")
-						.padding()
+					Text("(None yet)")
 				}
+				if (!myConversations.isEmpty) {
+					Text("My Conversations").font(.title3)
+					List(myConversations) { c in
+						HStack(spacing: 10) {
+							Button("Listen", systemImage: "ear") {
+								logger.info("Hit listen button on \(c.id) (\(c.name))")
+								maybeListen?(profile.listenProfile.fromMyWhisperConversation(c))
+							}
+							Text("\(c.name)").lineLimit(nil)
+						}
+						.labelStyle(.iconOnly)
+						.buttonStyle(.borderless)
+					}
+					.listStyle(.inset)
+				}
+				Spacer()
 				#if DEBUG
 				ListenLinkView(maybeListen: maybeListen)
 				#endif
 			}
-			.toolbarTitleDisplayMode(.large)
-			.navigationTitle("Conversations")
+			.navigationTitle("Listen")
 			#if targetEnvironment(macCatalyst)
 			.toolbar {
 				Button(action: { dismiss() }, label: { Text("Close") } )
@@ -58,12 +73,13 @@ struct ListenProfileView: View {
 			.padding(10)
 			.onChange(of: profile.timestamp, initial: true, updateFromProfile)
 		}
-		.onChange(of: scenePhase, initial: true, profile.update)
+		.onAppear(perform: profile.update)
 		.onDisappear(perform: profile.update)
     }
     
     func updateFromProfile() {
 		conversations = profile.listenProfile.conversations()
+		myConversations = profile.userPassword.isEmpty ? [] : profile.whisperProfile.conversations()
     }
 }
 

--- a/whisper/Views/ProfileViews/WhisperProfileView.swift
+++ b/whisper/Views/ProfileViews/WhisperProfileView.swift
@@ -41,8 +41,8 @@ struct WhisperProfileView: View {
 					updateFromProfile()
 				}
 			}
-			.toolbarTitleDisplayMode(.large)
-			.navigationTitle("Conversations")
+			.listStyle(.inset)
+			.navigationTitle("Whisper")
 			.toolbar {
 				Button(action: addConversation, label: { Text("Add") } )
 				EditButton()
@@ -52,7 +52,7 @@ struct WhisperProfileView: View {
 			}
 			.onChange(of: profile.timestamp, initial: true, updateFromProfile)
         }
-		.onChange(of: scenePhase, initial: true, profile.update)
+		.onAppear(perform: profile.update)
 		.onDisappear(perform: profile.update)
     }
 

--- a/whisper/Views/WhisperView/WhisperViewModel.swift
+++ b/whisper/Views/WhisperView/WhisperViewModel.swift
@@ -303,7 +303,9 @@ final class WhisperViewModel: ObservableObject {
 		remote: Remote,
 		info: WhisperProtocol.ClientInfo
 	) -> Candidate {
-		let authorized = profile.isListener(conversation, info: info)
+		// I am always an authorized listener for my own conversations
+		let myself = ListenerInfo(id: UserProfile.shared.id, username: UserProfile.shared.username)
+		let authorized =  info.profileId == UserProfile.shared.id ? myself : profile.isListener(conversation, info: info)
 		let candidate = candidates[remote.id] ?? Candidate(remote: remote, info: info, isPending: authorized == nil)
 		candidates[candidate.id] = candidate
 		if !info.username.isEmpty {

--- a/whisper/whisperApp.swift
+++ b/whisper/whisperApp.swift
@@ -70,7 +70,7 @@ let logger = Logger()
 
 @main
 struct whisperApp: App {
-    @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+	@UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     
     @State var mode: OperatingMode = .ask
     @State var conversation: (any Conversation)? = nil


### PR DESCRIPTION
We now recognize when a user is whispering to themself and automatically authorize them for the conversation (without adding it to the previous conversation list).  This allows people who use shared profiles to have one of their devices be dedicated to listening and have it always be able to listen to every conversation (including via local discovery) without ever being sent a link.

This fixes #64.

This was a deeper fix than I was expecting.  I was expecting the UI changes in the ListenProfileView to separate my conversations from those others have sent me links for, but I didn't realize I would have to auto-create a listen conversation from a whisper conversation on the fly.

While I was in the profile code, I also cleaned up logging around shared profile updates, put a 10 second throttle on profile updates (no more than one every 10 seconds), and restricted new updates to two situations (after the initial fetch at launch):

1. When a profile-sensitive view (such as choice view or whisper profile view or listen profile view) appears (or is uncovered by a modal going away)
2. When the app, in choice view (or one covering it), comes back to the front (i.e., becomes active)

This has greatly reduced traffic to the server but still has a good chance of noticing changes made on other machines even though the app is running.

Finally, I found a subtle bug on the server (clickonetwo/whisper-server#25) around shared profiles: since profile names are uploaded on launch, out-of-date shared clients could confuse the server by sending an out-of-date name for the shared profile.  This would in turn screw up other shared clients.

The fix was not to record launch-time names for shared profiles, only for local ones.  That way there's no chance of conflict and the updated name will still be known at next launch even if the original upload of it failed.