### PR TITLE
Prefer Internet to Bluetooth when Listening

### DIFF
--- a/Test Flight Release Notes.txt
+++ b/Test Flight Release Notes.txt
@@ -259,3 +259,14 @@ v2 BUILD 19 and 20 (external):
 The default Listener layout now matches the Whisperer's (live text on the bottom, past text on the top).  This makes the past text read from top to bottom, which is a lot easier for most people to understand.
 
 If you never explicitly set your preference (in Settings) for this, your Listener layout will switch when you install this build.  If you did explicitly set it to be "top" or "bottom" live text, then it will stay the way you set it.
+
+v2 BUILD 21 (external):
+This build introduces changes in the way you start whispering or listening:
+
+1. There is no more "discovery" of ongoing conversations.  You always have to pick a specific conversation to whisper on or listen to.
+
+2. The default behavior of tapping the Whisper button is now customizable (via Settings). You can either have it (a) pop up the list of conversations for you to choose one, (b) start your default conversation, or (c) start the last conversation you were whispering on.
+
+3. The default behavior of tapping the Listen button is now customizable (via Settings). You can either have it (a) pop up the list of conversations for you to choose one or (b) reconnect to the last conversation you were listening to.
+
+No matter your preference settings, if there is only one conversation you have ever used (for whispering or listening, respectively), then tapping the Whisper or Listen button will always select that conversation.  You can always long-press the button to pop up the list of conversations.

--- a/whisper.xcodeproj/project.pbxproj
+++ b/whisper.xcodeproj/project.pbxproj
@@ -637,7 +637,7 @@
 				CODE_SIGN_ENTITLEMENTS = whisper/whisper.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				DEVELOPMENT_ASSET_PATHS = "\"whisper/Preview Content\"";
 				DEVELOPMENT_TEAM = 9BJ65G9LZ5;
 				ENABLE_PREVIEWS = YES;
@@ -679,7 +679,7 @@
 				CODE_SIGN_ENTITLEMENTS = whisper/whisper.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				DEVELOPMENT_ASSET_PATHS = "\"whisper/Preview Content\"";
 				DEVELOPMENT_TEAM = 9BJ65G9LZ5;
 				ENABLE_PREVIEWS = YES;

--- a/whisper/Models/PreferenceData.swift
+++ b/whisper/Models/PreferenceData.swift
@@ -138,6 +138,16 @@ struct PreferenceData {
 		}
 	}
 
+	// behavior for Whisper tap
+	static func whisperTapAction() -> String {
+		return defaults.string(forKey: "whisper_tap_preference") ?? "show"
+	}
+
+	// behavior for Listen tap
+	static func listenTapAction() -> String {
+		return defaults.string(forKey: "listen_tap_preference") ?? "show"
+	}
+
     // layout control of listeners
     static func listenerMatchesWhisperer() -> Bool {
         return (defaults.string(forKey: "newest_whisper_location_preference") ?? "bottom") == "bottom"

--- a/whisper/Models/Transports/Bluetooth/BluetoothFactory.swift
+++ b/whisper/Models/Transports/Bluetooth/BluetoothFactory.swift
@@ -18,7 +18,7 @@ final class BluetoothFactory: NSObject, TransportFactory {
 		return Publisher(c)
 	}
 
-	func subscriber(_ c: ListenConversation?) -> Subscriber {
+	func subscriber(_ c: ListenConversation) -> Subscriber {
 		return Subscriber(c)
 	}
 

--- a/whisper/Models/Transports/Bluetooth/BluetoothListenTransport.swift
+++ b/whisper/Models/Transports/Bluetooth/BluetoothListenTransport.swift
@@ -116,7 +116,7 @@ final class BluetoothListenTransport: SubscribeTransport {
 					logger.error("Ignoring advertisement with no conversation id from: \(pair.0, privacy: .public)")
                     return
                 }
-				guard conversation == nil || BluetoothData.deviceId(conversation!.id) == id else {
+				guard BluetoothData.deviceId(conversation.id) == id else {
 					logger.info("Ignoring advertisement with non-matching conversation id from: \(pair.0)")
 					return
 				}
@@ -348,10 +348,10 @@ final class BluetoothListenTransport: SubscribeTransport {
     private var cancellables: Set<AnyCancellable> = []
     private var isInBackground = false
     private var scanRefreshCount = 0
-	private var conversation: ListenConversation? = nil
+	private var conversation: ListenConversation
 	private var failureCallback: ((String) -> Void)?
 
-	init(_ c: ListenConversation?) {
+	init(_ c: ListenConversation) {
         logger.log("Initializing Bluetooth listen transport")
 		self.conversation = c
     }
@@ -415,11 +415,7 @@ final class BluetoothListenTransport: SubscribeTransport {
         Timer.scheduledTimer(withTimeInterval: listenerAdTime, repeats: false) { _ in
             self.stopAdvertising()
         }
-		if let c = conversation {
-			factory.advertise(services: [BluetoothData.listenServiceUuid], localName: BluetoothData.deviceId(c.id))
-		} else {
-			factory.advertise(services: [BluetoothData.listenServiceUuid], localName: "discover")
-		}
+		factory.advertise(services: [BluetoothData.listenServiceUuid], localName: BluetoothData.deviceId(conversation.id))
     }
     
     private func stopAdvertising() {

--- a/whisper/Models/Transports/Bluetooth/BluetoothWhisperTransport.swift
+++ b/whisper/Models/Transports/Bluetooth/BluetoothWhisperTransport.swift
@@ -124,7 +124,7 @@ final class BluetoothWhisperTransport: PublishTransport {
             if uuids.contains(BluetoothData.listenServiceUuid) {
                 guard let adName = pair.1[CBAdvertisementDataLocalNameKey],
                       let id = adName as? String,
-					  id == "discover" || id == BluetoothData.deviceId(conversation.id)
+					  id == BluetoothData.deviceId(conversation.id)
                 else {
                     logger.error("Ignoring invalid advertisement from \(pair.0, privacy: .public)")
                     return

--- a/whisper/Models/Transports/Combo/ComboFactory.swift
+++ b/whisper/Models/Transports/Combo/ComboFactory.swift
@@ -18,7 +18,7 @@ final class ComboFactory: TransportFactory {
         return Publisher(conversation)
     }
     
-    func subscriber(_ conversation: ListenConversation?) -> Subscriber {
+    func subscriber(_ conversation: ListenConversation) -> Subscriber {
         return Subscriber(conversation)
     }
     

--- a/whisper/Models/Transports/Combo/ComboListenTransport.swift
+++ b/whisper/Models/Transports/Combo/ComboListenTransport.swift
@@ -104,7 +104,7 @@ final class ComboListenTransport: SubscribeTransport {
 		}
     }
     
-	private var conversation: ListenConversation?
+	private var conversation: ListenConversation
 	private var localFactory = BluetoothFactory.shared
 	private var localStatus: TransportStatus = .off
 	private var localTransport: LocalTransport?
@@ -117,7 +117,7 @@ final class ComboListenTransport: SubscribeTransport {
     private var cancellables: Set<AnyCancellable> = []
 	private var failureCallback: ((String) -> Void)?
 
-    init(_ conversation: ListenConversation?) {
+    init(_ conversation: ListenConversation) {
         logger.log("Initializing combo listen transport")
 		self.conversation = conversation
 		self.localFactory.statusSubject
@@ -166,8 +166,8 @@ final class ComboListenTransport: SubscribeTransport {
 	}
 
 	private func initializeTransports() {
-		if let c = conversation, globalStatus == .on {
-			let globalTransport = GlobalTransport(c)
+		if globalStatus == .on {
+			let globalTransport = GlobalTransport(conversation)
 			self.globalTransport = globalTransport
 			globalTransport.lostRemoteSubject
 				.sink { [weak self] in self?.removeRemote(remote: $0) }

--- a/whisper/Models/Transports/Combo/ComboListenTransport.swift
+++ b/whisper/Models/Transports/Combo/ComboListenTransport.swift
@@ -84,11 +84,6 @@ final class ComboListenTransport: SubscribeTransport {
     typealias GlobalTransport = TcpListenTransport
     typealias GlobalRemote = TcpListenTransport.Remote
     
-    enum Owner {
-        case local
-        case global
-    }
-    
     final class Wrapper: TransportRemote {
 		let id: String
 		let kind: TransportKind
@@ -218,7 +213,7 @@ final class ComboListenTransport: SubscribeTransport {
 		}
 	}
 
-	private func staggerStop(_ kind: Owner) {
+	private func staggerStop(_ kind: TransportKind) {
 		if let timer = staggerTimer {
 			staggerTimer = nil
 			timer.invalidate()

--- a/whisper/Models/Transports/Combo/ComboListenTransport.swift
+++ b/whisper/Models/Transports/Combo/ComboListenTransport.swift
@@ -199,20 +199,20 @@ final class ComboListenTransport: SubscribeTransport {
 	}
 
 	private func staggerStart() {
-		if let local = localTransport {
-			logger.info("Starting Bluetooth in advance of Internet")
-			local.start(failureCallback: failureCallback!)
+		if let global = globalTransport {
+			logger.info("Starting Internet in advance of Bluetooth")
+			global.start(failureCallback: self.failureCallback!)
 			staggerTimer = Timer.scheduledTimer(withTimeInterval: TimeInterval(listenerWaitTime), repeats: false) { _ in
 				// run loop will invalidate the timer
 				self.staggerTimer = nil
-				if let global = self.globalTransport {
-					logger.info("Starting Internet after Bluetooth")
-					global.start(failureCallback: self.failureCallback!)
+				if let local = self.localTransport {
+					logger.info("Starting Bluetooth after Internet")
+					local.start(failureCallback: self.failureCallback!)
 				}
 			}
-		} else if let global = globalTransport {
-			logger.info("Starting Internet only because Bluetooth not available")
-			global.start(failureCallback: self.failureCallback!)
+		} else if let local = localTransport {
+			logger.info("Starting only Bluetooth because Internet not available")
+			local.start(failureCallback: failureCallback!)
 		} else {
 			fatalError("Cannot listen because neither Bluetooth nor Internet is available")
 		}

--- a/whisper/Models/Transports/Tcp/TcpFactory.swift
+++ b/whisper/Models/Transports/Tcp/TcpFactory.swift
@@ -29,11 +29,8 @@ final class TcpFactory: TransportFactory {
         return TcpWhisperTransport(conversation)
     }
     
-    func subscriber(_ conversation: ListenConversation?) -> Subscriber {
-        guard let c = conversation else {
-            fatalError("TCP listen transport requires a whisper URL")
-        }
-        return TcpListenTransport(c)
+    func subscriber(_ conversation: ListenConversation) -> Subscriber {
+        return TcpListenTransport(conversation)
     }
     
     //MARK: private types, properties, and initialization

--- a/whisper/Models/Transports/Tcp/TcpListenTransport.swift
+++ b/whisper/Models/Transports/Tcp/TcpListenTransport.swift
@@ -98,10 +98,7 @@ final class TcpListenTransport: SubscribeTransport {
     private var remotes: [String:Remote] = [:]
     private var whisperer: Remote?
 
-    init(_ conversation: ListenConversation?) {
-		guard let conversation = conversation else {
-			fatalError("Can't listen over the network without a conversation")
-		}
+    init(_ conversation: ListenConversation) {
         self.clientId = PreferenceData.clientId
         self.conversation = conversation
 		self.channelName = conversation.id

--- a/whisper/Models/Transports/TransportProtocol.swift
+++ b/whisper/Models/Transports/TransportProtocol.swift
@@ -36,7 +36,7 @@ protocol TransportFactory {
     var statusSubject: CurrentValueSubject<TransportStatus, Never> { get }
     
     func publisher(_ conversation: WhisperConversation) -> Publisher
-    func subscriber(_ conversation: ListenConversation?) -> Subscriber
+    func subscriber(_ conversation: ListenConversation) -> Subscriber
 }
 
 protocol TransportRemote: Identifiable {
@@ -72,7 +72,7 @@ protocol PublishTransport: Transport {
 }
 
 protocol SubscribeTransport: Transport {
-	init(_ conversation: ListenConversation?)
+	init(_ conversation: ListenConversation)
 
 	var contentSubject: PassthroughSubject<(remote: Remote, chunk: WhisperProtocol.ProtocolChunk), Never> { get }
 

--- a/whisper/Models/UserProfile/ListenProfile.swift
+++ b/whisper/Models/UserProfile/ListenProfile.swift
@@ -188,6 +188,9 @@ final class ListenProfile: Codable {
 				self.timestamp = profile.timestamp
 				save(localOnly: true)
 				notifyChange?()
+			} else if code == 404 {
+				// this is supposed to be a shared profile, but the server doesn't have it?!
+				save(verb: "POST")
 			}
 		}
 		let path = "/api/v2/listenProfile/\(id)"

--- a/whisper/Models/UserProfile/ListenProfile.swift
+++ b/whisper/Models/UserProfile/ListenProfile.swift
@@ -18,10 +18,19 @@ final class ListenConversation: Conversation, Encodable, Decodable {
 		self.id = uuid ?? UUID().uuidString
 	}
 
-	// decreasing sort by last-used date then increasing sort by name within date bucket
+	// equality by id
+	static func ==(_ left: ListenConversation, _ right: ListenConversation) -> Bool {
+		return left.id == right.id
+	}
+
+	// decreasing sort by last-used date then increasing sort by name (then ID) within date bucket
 	static func <(_ left: ListenConversation, _ right: ListenConversation) -> Bool {
 		if left.lastListened == right.lastListened {
-			return left < right
+			if left.name == right.name {
+				return left.id < right.id
+			} else {
+				return left.name < right.name
+			}
 		} else {
 			return left.lastListened > right.lastListened
 		}

--- a/whisper/Models/UserProfile/ListenProfile.swift
+++ b/whisper/Models/UserProfile/ListenProfile.swift
@@ -242,6 +242,7 @@ final class ListenProfile: Codable {
 		var request = URLRequest(url: url)
 		request.setValue("Bearer \(serverPassword)", forHTTPHeaderField: "Authorization")
 		request.setValue(PreferenceData.clientId, forHTTPHeaderField: "X-Client-Id")
+		request.setValue("\"  impossible-timestamp   \"", forHTTPHeaderField: "If-None-Match")
 		request.httpMethod = "GET"
 		Data.executeJSONRequest(request, handler: handler)
 	}

--- a/whisper/Models/UserProfile/UserProfile.swift
+++ b/whisper/Models/UserProfile/UserProfile.swift
@@ -281,6 +281,7 @@ final class UserProfile: Identifiable, ObservableObject {
 		var request = URLRequest(url: url)
 		request.setValue("Bearer \(serverPassword)", forHTTPHeaderField: "Authorization")
 		request.setValue(PreferenceData.clientId, forHTTPHeaderField: "X-Client-Id")
+		request.setValue("\"  impossible-name   \"", forHTTPHeaderField: "If-None-Match")
 		request.httpMethod = "GET"
 		Data.executeJSONRequest(request, handler: nameHandler)
 	}

--- a/whisper/Models/UserProfile/UserProfile.swift
+++ b/whisper/Models/UserProfile/UserProfile.swift
@@ -43,8 +43,18 @@ final class UserProfile: Identifiable, ObservableObject {
 		} else {
 			serverPassword = SHA256.hash(data: Data(password.utf8)).map{ String(format: "%02x", $0) }.joined()
 		}
-		whisperProfile = WhisperProfile.load(id, serverPassword: serverPassword) ?? WhisperProfile(id, profileName: name)
-		listenProfile = ListenProfile.load(id, serverPassword: serverPassword) ?? ListenProfile(id)
+		if let wp = WhisperProfile.load(id, serverPassword: serverPassword),
+		   let lp = ListenProfile.load(id, serverPassword: serverPassword) {
+			whisperProfile = wp
+			listenProfile = lp
+		} else {
+			// we failed to load completely, so reset the profile completely except for the name
+			self.id = UUID().uuidString
+			userPassword = ""
+			serverPassword = ""
+			whisperProfile = WhisperProfile(id, profileName: name)
+			listenProfile = ListenProfile(id)
+		}
 	}
 
 	var username: String {
@@ -141,6 +151,9 @@ final class UserProfile: Identifiable, ObservableObject {
 					self.name = name
 					self.save(localOnly: true)
 				}
+			} else if code == 404 {
+				// this is supposed to be a shared profile, but the server doesn't have it?!
+				save(verb: "POST")
 			}
 		}
 		let path = "/api/v2/userProfile/\(id)"
@@ -198,10 +211,12 @@ final class UserProfile: Identifiable, ObservableObject {
 		func loadHandler(_ success: Bool, _ message: String) {
 			if !success {
 				logger.error("Resetting user profile \(id, privacy: .public) due to failure receiving shared profile.")
-				userPassword = ""
-				serverPassword = ""
-				whisperProfile = WhisperProfile(self.id, profileName: name)
-				listenProfile = ListenProfile(self.id)
+				DispatchQueue.main.async {
+					self.userPassword = ""
+					self.serverPassword = ""
+					self.whisperProfile = WhisperProfile(self.id, profileName: self.name)
+					self.listenProfile = ListenProfile(self.id)
+				}
 			}
 			completionHandler(success, message)
 		}

--- a/whisper/Models/UserProfile/UserProfile.swift
+++ b/whisper/Models/UserProfile/UserProfile.swift
@@ -12,12 +12,6 @@ protocol Conversation: Identifiable, Equatable, Comparable {
 	var name: String { get }
 }
 
-extension Conversation {
-	static func ==(_ left: Self, _ right: Self) -> Bool {
-		return left.id == right.id
-	}
-}
-
 final class UserProfile: Identifiable, ObservableObject {
 	static private(set) var shared = load() ?? create()
 

--- a/whisper/Models/UserProfile/WhisperProfile.swift
+++ b/whisper/Models/UserProfile/WhisperProfile.swift
@@ -15,6 +15,11 @@ final class WhisperConversation: Conversation, Encodable, Decodable {
 		self.id = uuid ?? UUID().uuidString
 	}
 
+	// equality by id
+	static func ==(_ left: WhisperConversation, _ right: WhisperConversation) -> Bool {
+		return left.id == right.id
+	}
+
 	// lexicographic ordering by name
 	// since two conversations can have the same name, we fall back
 	// to lexicographic ID order to break ties with stability.
@@ -73,7 +78,7 @@ final class WhisperProfile: Codable {
 			guard let existing = table[c.id] else {
 				fatalError("Tried to set last whisper conversation to one not in whisper table")
 			}
-			lastId = c.id
+			lastId = existing.id
 			timestamp = Int(Date.now.timeIntervalSince1970)
 			save()
 		}

--- a/whisper/Models/UserProfile/WhisperProfile.swift
+++ b/whisper/Models/UserProfile/WhisperProfile.swift
@@ -37,19 +37,46 @@ final class WhisperProfile: Codable {
 	private var id: String
 	private var table: [String: WhisperConversation]
 	private var defaultId: String
+	private var lastId: String
 	private var timestamp: Int
 	private var serverPassword: String = ""
 
 	private enum CodingKeys: String, CodingKey {
-		case id, table, defaultId, timestamp
+		case id, table, defaultId, lastId, timestamp
 	}
 
 	init(_ profileId: String, profileName: String) {
 		id = profileId
 		table = [:]
 		defaultId = "none"
+		lastId = "none"
 		timestamp = Int(Date.now.timeIntervalSince1970)
 		ensureFallback(profileName)
+	}
+
+	var lastUsed: WhisperConversation? {
+		get {
+			if let existing = table[lastId] {
+				return existing
+			}
+			return nil
+		}
+		set(c) {
+			guard let c = c else {
+				lastId = "none"
+				return
+			}
+			guard c.id != lastId else {
+				// nothing to do
+				return
+			}
+			guard let existing = table[c.id] else {
+				fatalError("Tried to set last whisper conversation to one not in whisper table")
+			}
+			lastId = c.id
+			timestamp = Int(Date.now.timeIntervalSince1970)
+			save()
+		}
 	}
 
 	var fallback: WhisperConversation {

--- a/whisper/Models/UserProfile/WhisperProfile.swift
+++ b/whisper/Models/UserProfile/WhisperProfile.swift
@@ -42,7 +42,7 @@ final class WhisperProfile: Codable {
 	private var id: String
 	private var table: [String: WhisperConversation]
 	private var defaultId: String
-	private var lastId: String
+	private var lastId: String?
 	private var timestamp: Int
 	private var serverPassword: String = ""
 
@@ -54,21 +54,21 @@ final class WhisperProfile: Codable {
 		id = profileId
 		table = [:]
 		defaultId = "none"
-		lastId = "none"
+		lastId = nil
 		timestamp = Int(Date.now.timeIntervalSince1970)
 		ensureFallback(profileName)
 	}
 
 	var lastUsed: WhisperConversation? {
 		get {
-			if let existing = table[lastId] {
+			if let val = lastId, let existing = table[val] {
 				return existing
 			}
 			return nil
 		}
 		set(c) {
 			guard let c = c else {
-				lastId = "none"
+				lastId = nil
 				return
 			}
 			guard c.id != lastId else {
@@ -256,6 +256,9 @@ final class WhisperProfile: Codable {
 				self.timestamp = profile.timestamp
 				save(localOnly: true)
 				notifyChange?()
+			} else if code == 404 {
+				// this is supposed to be a shared profile, but the server doesn't have it?!
+				save(verb: "POST")
 			}
 		}
 		let path = "/api/v2/whisperProfile/\(id)"

--- a/whisper/Models/UserProfile/WhisperProfile.swift
+++ b/whisper/Models/UserProfile/WhisperProfile.swift
@@ -312,6 +312,7 @@ final class WhisperProfile: Codable {
 		var request = URLRequest(url: url)
 		request.setValue("Bearer \(serverPassword)", forHTTPHeaderField: "Authorization")
 		request.setValue(PreferenceData.clientId, forHTTPHeaderField: "X-Client-Id")
+		request.setValue("\"  impossible-timestamp   \"", forHTTPHeaderField: "If-None-Match")
 		request.httpMethod = "GET"
 		Data.executeJSONRequest(request, handler: handler)
 	}

--- a/whisper/Models/WhisperProtocol.swift
+++ b/whisper/Models/WhisperProtocol.swift
@@ -246,9 +246,9 @@ final class WhisperProtocol {
 			return ProtocolChunk(offset: ControlOffset.dropping.rawValue, text: info.toString())
         }
         
-		static func listenOffer(_ c: (any Conversation)? = nil) -> ProtocolChunk {
-			let info = ClientInfo(conversationId: c?.id ?? "discover",
-                                  conversationName: "",
+		static func listenOffer(_ c: any Conversation) -> ProtocolChunk {
+			let info = ClientInfo(conversationId: c.id,
+								  conversationName: c.name,
                                   clientId: PreferenceData.clientId,
                                   profileId: UserProfile.shared.id,
                                   username: "",

--- a/whisper/Settings.bundle/Root.plist
+++ b/whisper/Settings.bundle/Root.plist
@@ -10,6 +10,48 @@
 			<key>Type</key>
 			<string>PSMultiValueSpecifier</string>
 			<key>Title</key>
+			<string>Tap on Whisper to</string>
+			<key>Key</key>
+			<string>whisper_tap_preference</string>
+			<key>DefaultValue</key>
+			<string>show</string>
+			<key>Titles</key>
+			<array>
+				<string>show conversations</string>
+				<string>start default conversation</string>
+				<string>start last-used conversation</string>
+			</array>
+			<key>Values</key>
+			<array>
+				<string>show</string>
+				<string>default</string>
+				<string>last</string>
+			</array>
+		</dict>
+		<dict>
+			<key>Type</key>
+			<string>PSMultiValueSpecifier</string>
+			<key>Title</key>
+			<string>Tap on Listen to</string>
+			<key>Key</key>
+			<string>listen_tap_preference</string>
+			<key>DefaultValue</key>
+			<string>show</string>
+			<key>Titles</key>
+			<array>
+				<string>show conversations</string>
+				<string>listen to last-used conversation</string>
+			</array>
+			<key>Values</key>
+			<array>
+				<string>show</string>
+				<string>last</string>
+			</array>
+		</dict>
+		<dict>
+			<key>Type</key>
+			<string>PSMultiValueSpecifier</string>
+			<key>Title</key>
 			<string>Listener sees newest whisper in</string>
 			<key>Key</key>
 			<string>newest_whisper_location_preference</string>

--- a/whisper/Views/ListenView/ListenView.swift
+++ b/whisper/Views/ListenView/ListenView.swift
@@ -12,7 +12,7 @@ struct ListenView: View {
 
     @Binding var mode: OperatingMode
 	@Binding var restart: Bool
-    var conversation: ListenConversation?
+    var conversation: ListenConversation
 
     @FocusState var focusField: Bool
     @StateObject private var model: ListenViewModel
@@ -23,7 +23,7 @@ struct ListenView: View {
     // set this once at view creation
     private var listenerLiveTextOnTop = !PreferenceData.listenerMatchesWhisperer()
     
-	init(mode: Binding<OperatingMode>, restart: Binding<Bool>, conversation: ListenConversation?) {
+	init(mode: Binding<OperatingMode>, restart: Binding<Bool>, conversation: ListenConversation) {
         self._mode = mode
 		self._restart = restart
 		self.conversation = conversation
@@ -156,6 +156,9 @@ struct ListenView_Previews: PreviewProvider {
 	static let restart: Binding<Bool> = makeBinding(false)
 
     static var previews: some View {
-		ListenView(mode: mode, restart: restart, conversation: nil)
+		ListenView(mode: mode, 
+				   restart: restart,
+				   conversation: UserProfile.shared.listenProfile.fromMyWhisperConversation(UserProfile.shared.whisperProfile.fallback)
+				   )
     }
 }

--- a/whisper/Views/ListenView/WhisperersView.swift
+++ b/whisper/Views/ListenView/WhisperersView.swift
@@ -59,5 +59,5 @@ struct WhisperersView: View {
 }
 
 #Preview {
-	WhisperersView(model: ListenViewModel(nil))
+	WhisperersView(model: ListenViewModel(UserProfile.shared.listenProfile.fromMyWhisperConversation(UserProfile.shared.whisperProfile.fallback)))
 }

--- a/whisper/Views/MainView/ChoiceView.swift
+++ b/whisper/Views/MainView/ChoiceView.swift
@@ -87,7 +87,20 @@ struct ChoiceView: View {
                     .highPriorityGesture(
                         TapGesture()
                             .onEnded { _ in
-								maybeWhisper(profile.whisperProfile.fallback)
+								switch PreferenceData.whisperTapAction() {
+								case "show":
+									showWhisperConversations = true
+								case "default":
+									maybeWhisper(profile.whisperProfile.fallback)
+								case "last":
+									if let c = profile.whisperProfile.lastUsed {
+										maybeWhisper(c)
+									} else {
+										showWhisperConversations = true
+									}
+								default:
+									fatalError("Illegal preference value for Whisper tap action: \(PreferenceData.whisperTapAction())")
+								}
                             }
                     )
                     .sheet(isPresented: $showWhisperConversations) {
@@ -111,11 +124,17 @@ struct ChoiceView: View {
                     .highPriorityGesture(
                         TapGesture()
                             .onEnded { _ in
-								if transportStatus == .on {
-									conversation = nil
-									mode = .listen
-								} else {
+								switch PreferenceData.listenTapAction() {
+								case "show":
 									showListenConversations = true
+								case "last":
+									if let c = profile.listenProfile.conversations().first {
+										maybeListen(c)
+									} else {
+										showListenConversations = true
+									}
+								default:
+									fatalError("Illegal preference value for Listen tap action: \(PreferenceData.listenTapAction())")
 								}
                             }
                     )
@@ -220,6 +239,7 @@ struct ChoiceView: View {
 				showNoConnection = true
 			} else {
 				conversation = c
+				profile.whisperProfile.lastUsed = c
 				mode = .whisper
 			}
 		}

--- a/whisper/Views/MainView/ChoiceView.swift
+++ b/whisper/Views/MainView/ChoiceView.swift
@@ -87,6 +87,11 @@ struct ChoiceView: View {
                     .highPriorityGesture(
                         TapGesture()
                             .onEnded { _ in
+								let conversations = profile.whisperProfile.conversations()
+								if conversations.count == 1 {
+									maybeWhisper(conversations.first)
+									return
+								}
 								switch PreferenceData.whisperTapAction() {
 								case "show":
 									showWhisperConversations = true
@@ -124,6 +129,11 @@ struct ChoiceView: View {
                     .highPriorityGesture(
                         TapGesture()
                             .onEnded { _ in
+								let conversations = profile.listenProfile.conversations()
+								if conversations.count == 1 {
+									maybeListen(conversations.first)
+									return
+								}
 								switch PreferenceData.listenTapAction() {
 								case "show":
 									showListenConversations = true

--- a/whisper/Views/MainView/MainView.swift
+++ b/whisper/Views/MainView/MainView.swift
@@ -37,9 +37,9 @@ struct MainView: View {
 				Text("The Whisperer has paused the conversation. Click OK to reconnect, Cancel to stop listening.")
 			}
         case .listen:
-			ListenView(mode: $mode, restart: $restart, conversation: conversation as? ListenConversation)
+			ListenView(mode: $mode, restart: $restart, conversation: conversation as! ListenConversation)
         case .whisper:
-			WhisperView(mode: $mode, conversation: conversation as? WhisperConversation ?? UserProfile.shared.whisperProfile.fallback)
+			WhisperView(mode: $mode, conversation: conversation as! WhisperConversation)
         }
     }
 }

--- a/whisper/Views/ProfileViews/ListenProfileView.swift
+++ b/whisper/Views/ProfileViews/ListenProfileView.swift
@@ -42,7 +42,7 @@ struct ListenProfileView: View {
 						.buttonStyle(.borderless)
 					}
 				} else {
-					Text("(None yet)")
+					Text("(No past conversations)")
 				}
 				if (!myConversations.isEmpty) {
 					Text("My Conversations").font(.title3)
@@ -92,7 +92,11 @@ struct ListenLinkView: View {
 	var body: some View {
 		Form {
 			Section("Paste link here to listen") {
-				TextField("Conversation link", text: $link)
+				TextField("Conversation link", text: $link, axis: .vertical)
+					.lineLimit(2...5)
+					.submitLabel(.join)
+					.textInputAutocapitalization(.never)
+					.disableAutocorrection(true)
 					.onSubmit {
 						if let id = PreferenceData.publisherUrlToConversationId(url: link) {
 							let conversation = UserProfile.shared.listenProfile.fromLink(id)

--- a/whisper/Views/WhisperView/WhisperViewModel.swift
+++ b/whisper/Views/WhisperView/WhisperViewModel.swift
@@ -251,7 +251,7 @@ final class WhisperViewModel: ObservableObject {
 			guard let info = WhisperProtocol.ClientInfo.fromString(chunk.text) else {
 				fatalError("Received a presence message with invalid data: \(chunk.toString())")
 			}
-			guard info.conversationId == "discover" || info.conversationId == conversation.id else {
+			guard info.conversationId == conversation.id else {
 				logger.info("Ignoring a presence message about the wrong conversation: \(info.conversationId)")
 				return
 			}
@@ -261,15 +261,9 @@ final class WhisperViewModel: ObservableObject {
 				let candidate = candidateFor(remote: remote, info: info)
 				if candidate.isPending {
 					if offset == .listenOffer {
-						if info.conversationId == "discover" {
-							// this is a user who has never been in this conversation before,
-							// so he's not allowed to discover this conversation is available
-							logger.info("Ignoring a discovery offer an from unknown listener")
-						} else {
-							logger.info("Sending whisper offer to new \(remote.kind) listener: \(candidate.id)")
-							let chunk = WhisperProtocol.ProtocolChunk.whisperOffer(conversation)
-							transport.sendControl(remote: candidate.remote, chunk: chunk)
-						}
+						logger.info("Sending whisper offer to new \(remote.kind) listener: \(candidate.id)")
+						let chunk = WhisperProtocol.ProtocolChunk.whisperOffer(conversation)
+						transport.sendControl(remote: candidate.remote, chunk: chunk)
 					} else {
 						logger.info("Making invite for new \(remote.kind) listener: \(candidate.id)")
 						invites = candidates.values.filter{$0.isPending}.sorted()


### PR DESCRIPTION
In order to do this, we got rid of discovery; the listener must pick a specific conversation to listen to.  (This is also useful in avoiding app store complaints about chat roulette.)

This fixes #68.
